### PR TITLE
Fix#131 so get attr

### DIFF
--- a/hecuba/IStorage.py
+++ b/hecuba/IStorage.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 from time import time
 from hecuba import config, log
 import re
-
+import copy
 
 class AlreadyPersistentError(RuntimeError):
     pass
@@ -179,9 +179,11 @@ class IStorage:
         cname, module = IStorage.process_path(obj_info['type'])
         mod = __import__(module, globals(), locals(), [cname], 0)
         # new name as ksp+table+obj_class_name
-        obj_info['name'] = so_name
-        obj_info['storage_id'] = storage_id
-        so = getattr(mod, cname)(**obj_info)
+        args = copy.deepcopy(obj_info)
+        args['name'] = so_name
+        args['storage_id'] = storage_id
+        args.pop('type')
+        so = getattr(mod, cname)(**args)
         # sso._storage_id = storage_id
         return so
 

--- a/hecuba/IStorage.py
+++ b/hecuba/IStorage.py
@@ -59,8 +59,11 @@ class IStorage:
         Returns:
             tuple containing class_name and module
         """
+
         if module_path == 'numpy.ndarray':
             return 'StorageNumpy', 'hecuba.hnumpy'
+        if module_path == 'StorageDict':
+            return 'StorageDict', 'hecuba.hdict'
         last = 0
         for key, i in enumerate(module_path):
             if i == '.' and key > last:
@@ -169,6 +172,18 @@ class IStorage:
         q = config.session.execute("SELECT table_name FROM  system_schema.tables WHERE keyspace_name = %s",
                                    [self._ksp])
         return len(filter(lambda (t_name, ): m.match(t_name), q))
+
+
+
+    def _build_istorage_obj(self, obj_info, so_name, storage_id):
+        cname, module = IStorage.process_path(obj_info['type'])
+        mod = __import__(module, globals(), locals(), [cname], 0)
+        # new name as ksp+table+obj_class_name
+        obj_info['name'] = so_name
+        obj_info['storage_id'] = storage_id
+        so = getattr(mod, cname)(**obj_info)
+        # sso._storage_id = storage_id
+        return so
 
     @staticmethod
     def build_remotely(new_args):

--- a/hecuba/storageobj.py
+++ b/hecuba/storageobj.py
@@ -503,9 +503,9 @@ class StorageObj(object, IStorage):
             item: the name of the attribute to be deleted
         """
         if self._is_persistent and item in self._persistent_attrs:
-            query = "UPDATE %s.%s SET %s = null WHERE storage_id = %s" \
-                    % (self._ksp, self._table, item, self._storage_id)
+            query = "UPDATE %s.%s SET %s = null WHERE storage_id = %s" % (self._ksp, self._table, item, self._storage_id)
             config.session.execute(query)
-
+            if self._persistent_props[item]['type'] not in IStorage._basic_types:
+                object.__delattr__(self, item)
         else:
             object.__delattr__(self, item)

--- a/tests/withcassandra/storageobj_tests.py
+++ b/tests/withcassandra/storageobj_tests.py
@@ -272,7 +272,7 @@ class StorageObjTest(unittest.TestCase):
         nopars2 = Test6StorageObj("hecuba_test.nonames")
         nopars2.test3[0] = '1', '2'
         time.sleep(2)
-        result = config.session.execute("SELECT val0, val1 FROM hecuba_test.nonames_test3_0 WHERE key0 = 0")
+        result = config.session.execute("SELECT val0, val1 FROM hecuba_test.nonames_test3 WHERE key0 = 0")
 
         rval0 = None
         rval1 = None


### PR DESCRIPTION
This fixes coherence problems where two StorageObj acting on the same table could change the data and it wasn't reflected. This behaviour was produced because the StorageObj had the data in memory and didn't access Cassandra.

Code cleanup and comments added, as well as tests reflecting the issues solved.
Solves the bug #131 