### PR TITLE
StorageDict sets Numpy unique uuid

### DIFF
--- a/hecuba/hdict.py
+++ b/hecuba/hdict.py
@@ -536,6 +536,8 @@ class StorageDict(dict, IStorage):
                 dict.__setitem__(self, key, val)
             else:
                 if isinstance(val, IStorage) and not val._is_persistent:
+                    if isinstance(val, StorageNumpy):
+                        val._storage_id = uuid.uuid4()
                     attribute = self._columns[0][0]
                     count = self._count_name_collision(attribute)
                     # new name as ksp+table+obj_class_name


### PR DESCRIPTION
We decided to put a unique uuid to no persistent numpys that will be made persistent inside the StorageDict. Otherwise, their data was overlapped because they got assigned the same UUID.

We should think if we need the same in StorageObj, when replacing a numpy attribute with a new one.