### PR TITLE
Importing classes produces an understandable error

### DIFF
--- a/hecuba/IStorage.py
+++ b/hecuba/IStorage.py
@@ -185,7 +185,12 @@ class IStorage:
 
         # Import the class defined by obj_type
         cname, module = IStorage.process_path(obj_type)
-        mod = __import__(module, globals(), locals(), [cname], 0)
+
+        try:
+            mod = __import__(module, globals(), locals(), [cname], 0)
+        except ValueError:
+            raise ValueError("Can't import class {} from module {}".format(cname, module))
+
         is_class = getattr(mod, cname)
         if not issubclass(is_class, IStorage):
             raise TypeError("Trying to build remotely an object '%s' != IStorage subclass" % cname)


### PR DESCRIPTION
I added a try except code when we import classes from a file defined in the ClassField.

I found that pointing to a file that doesn't exist throw a very cryptic message. Now, after an import error the message includes the path and the object name which was trying to import.