### PR TITLE
Imports reorganized to make unit tests independent

### DIFF
--- a/app/result.py
+++ b/app/result.py
@@ -1,7 +1,0 @@
-from hecuba.storageobj import StorageObj
-
-class Result(StorageObj):
-    '''
-    @ClassField instances dict<<word:str>,instances:int>
-    '''
-    pass

--- a/tests/block_tests.py
+++ b/tests/block_tests.py
@@ -18,10 +18,11 @@ class BlockTest(unittest.TestCase):
     def test_static_creation(self):
         class res: pass
 
-        from app.words import Words
+        from class_definitions import Words
+        
         results = res()
         results.storage_id = uuid.uuid4()
-        results.class_name = 'app.words.Words'
+        results.class_name = 'tests.class_definitions.Words'
         results.name = 'ksp1.tab1'
         results.columns = [('val1', 'str')]
         results.entry_point = 'localhost'

--- a/tests/class_definitions.py
+++ b/tests/class_definitions.py
@@ -6,3 +6,10 @@ class Words(StorageObj):
     @ClassField words dict<<position:int>,wordinfo:str>
     '''
     pass
+
+
+class TestStorageObj(StorageObj):
+    '''
+       @ClassField test dict<<position:int>,text:str>
+    '''
+    pass

--- a/tests/storagedict_tests.py
+++ b/tests/storagedict_tests.py
@@ -1,17 +1,18 @@
 import unittest
 
-from hecuba import Config
-from hecuba.hdict import StorageDict
-
-
 class StorageDict_Tests(unittest.TestCase):
+    import hecuba
+    Config = hecuba.Config
+
     def setUp(self):
-        Config.reset(mock_cassandra=True)
+        self.Config.reset(mock_cassandra=True)
 
     def test_init(self):
         pass
 
     def inmemory_contains_test(self):
+        from hecuba.hdict import StorageDict
+
         pd = StorageDict(None,
                          [('pk1', 'int')],
                          [('val1', 'text')])
@@ -20,6 +21,8 @@ class StorageDict_Tests(unittest.TestCase):
         self.assertEqual('4', pd[3])
 
     def inmemory_keys_test(self):
+        from hecuba.hdict import StorageDict
+
         pd = StorageDict(None,
                          [('pk1', 'int'), ('pk2', 'int')],
                          [('val1', 'text')])
@@ -31,6 +34,8 @@ class StorageDict_Tests(unittest.TestCase):
         self.assertEqual({0, 1, 2, 3}, set(pd.keys()))
 
     def inmemory_composed_keys_test(self):
+        from hecuba.hdict import StorageDict
+
         pd = StorageDict(None,
                          [('pk1', 'int'), ('pk2', 'int')],
                          [('val1', 'text')])
@@ -42,6 +47,8 @@ class StorageDict_Tests(unittest.TestCase):
         self.assertEqual({(0, 1), (1, 1), (2, 0), (3, 1)}, set(pd.keys()))
 
     def inmemory_getitem_setitem_test(self):
+        from hecuba.hdict import StorageDict
+
         pd = StorageDict(None,
                          [('pk1', 'int'), ('pk2', 'int')],
                          [('val1', 'text')])

--- a/tests/storageobj_tests.py
+++ b/tests/storageobj_tests.py
@@ -2,24 +2,16 @@ import unittest
 
 from mock import Mock
 
-from hecuba.IStorage import IStorage
-from app.words import Words
-from hecuba import config, Config
-from hecuba.storageobj import StorageObj
-
-
-class TestStorageObj(StorageObj):
-    '''
-       @ClassField test dict<<position:int>,text:str>
-    '''
-    pass
-
 
 class StorageObjTest(unittest.TestCase):
+    import hecuba
+    Config = hecuba.Config
+
     def setUp(self):
-        Config.reset(mock_cassandra=True)
+        self.Config.reset(mock_cassandra=True)
 
     def test_parse_comments(self):
+        from hecuba.storageobj import StorageObj
         result = {'instances': {'columns': [('instances',
                                              'counter')],
                                 'primary_keys': [('word',
@@ -76,6 +68,7 @@ class StorageObjTest(unittest.TestCase):
         self.assertEqual(both2, p)
 
     def test_parse_2(self):
+        from hecuba.storageobj import StorageObj
         comment = "     @ClassField particles dict<<partid:int>,x:int,y:int,z:int>"
         p = StorageObj._parse_comments(comment)
         should_be = {'particles': {
@@ -86,6 +79,7 @@ class StorageObjTest(unittest.TestCase):
         self.assertEquals(p, should_be)
 
     def test_parse_3(self):
+        from hecuba.storageobj import StorageObj
         comment = "     @ClassField particles dict<<partid:int,part2:str>,x:int,y:int,z:int>"
         p = StorageObj._parse_comments(comment)
         should_be = {'particles': {
@@ -96,12 +90,15 @@ class StorageObjTest(unittest.TestCase):
         self.assertEquals(p, should_be)
 
     def test_init(self):
+        from hecuba import config
+        from class_definitions import Words
         # still in development
         config.session.execute = Mock(return_value=None)
         nopars = Words()
         config.session.execute.assert_not_called()
 
     def test_init_pdict(self):
+        from class_definitions import TestStorageObj
         t = TestStorageObj()
         t.test = {1: 'ciao'}
         #its not persistent, so in memory it is still a dict

--- a/tests/withcassandra/class_definitions.py
+++ b/tests/withcassandra/class_definitions.py
@@ -1,0 +1,216 @@
+from hecuba import StorageObj, StorageDict
+
+class SObj_Basic(StorageObj):
+    '''
+    @ClassField attr1 int
+    @ClassField attr2 double
+    @ClassField attr3 str
+    '''
+
+
+class SDict_SimpleTypeSpec(StorageDict):
+    '''
+    @TypeSpec <<id:int>,info:str>
+    '''
+
+
+class SDict_ComplexTypeSpec(StorageDict):
+    '''
+    @TypeSpec <<id:int>,state:tests.withcassandra.class_definitions.SObj_Basic>
+    '''
+
+
+class SObj_SimpleClassField(StorageObj):
+    '''
+    @ClassField attr1 int
+    @ClassField mydict dict <<key:str>,value:double>
+    @ClassField attr3 double
+    '''
+
+
+class SObj_ComplexClassField(StorageObj):
+    '''
+    @ClassField attr1 int
+    @ClassField mydict dict <<key:str>,state:tests.withcassandra.class_definitions.SObj_Basic>
+    @ClassField attr3 double
+    '''
+
+
+
+
+class MyStorageDict(StorageDict):
+    '''
+    @TypeSpec <<position:int>,val:int>
+    '''
+    pass
+
+
+class MyStorageDict2(StorageDict):
+    '''
+    @TypeSpec <<position:int, position2:str>,val:int>
+    '''
+    pass
+
+
+class MyStorageDict3(StorageDict):
+    '''
+    @TypeSpec <<str>,int>
+    '''
+
+
+class MyStorageObjC(StorageObj):
+    '''
+    @ClassField mona dict<<a:str>,b:int>
+    '''
+
+
+class MyStorageDictA(StorageDict):
+    '''
+    @TypeSpec <<a:str>,b:int>
+    '''
+
+
+class Words(StorageObj):
+    '''
+    @ClassField words dict<<position:int>,wordinfo:str>
+    '''
+    pass
+
+
+class TestSimple(StorageObj):
+    '''
+    @ClassField words dict<<position:int>,value:str>
+    '''
+    pass
+
+
+
+class Result(StorageObj):
+    '''
+    @ClassField instances dict<<word:str>,numinstances:int>
+    '''
+    pass
+
+
+class TestStorageObj(StorageObj):
+    '''
+       @ClassField test dict<<position:int>,text:str>
+    '''
+    pass
+
+
+class TestStorageIndexedArgsObj(StorageObj):
+    '''
+       @ClassField test dict<<position:int>,x:float,y:float,z:float>
+       @Index_on test x,y,z
+    '''
+    pass
+
+
+
+
+
+class Test2StorageObj(StorageObj):
+    '''
+       @ClassField name str
+       @ClassField age int
+    '''
+    pass
+
+
+class Test2StorageObjFloat(StorageObj):
+    '''
+       @ClassField name str
+       @ClassField age float
+    '''
+    pass
+
+
+class Test3StorageObj(StorageObj):
+    '''
+       @ClassField myso tests.withcassandra.class_definitions.Test2StorageObj
+       @ClassField myso2 tests.withcassandra.class_definitions.TestStorageObj
+       @ClassField myint int
+       @ClassField mystr str
+    '''
+    pass
+
+
+class Test4StorageObj(StorageObj):
+    '''
+       @ClassField myotherso tests.withcassandra.class_definitions.Test2StorageObj
+    '''
+    pass
+
+
+class Test4bStorageObj(StorageObj):
+    '''
+       @ClassField myotherso tests.withcassandra.class_definitions.Test2StorageObj
+    '''
+    pass
+
+
+class Test5StorageObj(StorageObj):
+    '''
+       @ClassField test2 dict<<position:int>,myso:tests.withcassandra.class_definitions.Test2StorageObj>
+    '''
+    pass
+
+
+class Test6StorageObj(StorageObj):
+    '''
+       @ClassField test3 dict<<int>,str,str>
+    '''
+    pass
+
+
+class Test7StorageObj(StorageObj):
+    '''
+       @ClassField test2 dict<<int>,tests.withcassandra.class_definitions.Test2StorageObj>
+    '''
+    pass
+
+
+class TestStorageObjNumpy(StorageObj):
+    '''
+       @ClassField mynumpy numpy.ndarray
+    '''
+    pass
+
+
+class TestStorageObjNumpyDict(StorageObj):
+    '''
+       @ClassField mynumpydict dict<<int>,numpy.ndarray>
+    '''
+    pass
+
+
+
+class TestAttributes(StorageObj):
+    '''
+       @ClassField key int
+    '''
+
+    value = None
+
+    def do_nothing_at_all(self):
+        pass
+
+    def setvalue(self, v):
+        self.value = v
+
+    def getvalue(self):
+        return self.value
+
+
+class mixObj(StorageObj):
+    '''
+    @ClassField floatfield float
+    @ClassField intField int
+    @ClassField strField str
+    @ClassField intlistField list <int>
+    @ClassField floatlistField list <float>
+    @ClassField strlistField list <str>
+    @ClassField dictField dict <<int>,str>
+    @ClassField inttupleField tuple <int, int>
+    '''

--- a/tests/withcassandra/storage_tests.py
+++ b/tests/withcassandra/storage_tests.py
@@ -1,16 +1,14 @@
 import unittest
 
-from app.words import Words
-from hecuba import Config, config
-from storage.api import getByID
-
 
 class StorageTests(unittest.TestCase):
-
     def setUp(self):
+        from hecuba import Config
         Config.reset(mock_cassandra=False)
 
     def test_getByID_block(self):
+        from storage.api import getByID
+        from class_definitions import Words
         # ki = KeyIter('testspace', 'tt', 'app.words.Words', 'fake-id', ['position'])
         SO = Words('so')
         b = SO.split().next()
@@ -19,6 +17,8 @@ class StorageTests(unittest.TestCase):
         self.assertEqual(b, new_block)
 
     def test_getByID_storage_obj(self):
+        from storage.api import getByID
+        from class_definitions import Words
         b = Words('testspace.tt')
         new_block = getByID(b.getID())
         self.assertEqual(b, new_block)

--- a/tests/withcassandra/storagedict_split_tests.py
+++ b/tests/withcassandra/storagedict_split_tests.py
@@ -1,49 +1,12 @@
 import unittest
 
-from hecuba import config
-from hecuba.hdict import StorageDict
-from hecuba.storageobj import StorageObj
-
-
-class SObj_Basic(StorageObj):
-    '''
-    @ClassField attr1 int
-    @ClassField attr2 double
-    @ClassField attr3 str
-    '''
-
-
-class SDict_SimpleTypeSpec(StorageDict):
-    '''
-    @TypeSpec <<id:int>,info:str>
-    '''
-
-
-class SDict_ComplexTypeSpec(StorageDict):
-    '''
-    @TypeSpec <<id:int>,state:tests.withcassandra.storagedict_split_tests.SObj_Basic>
-    '''
-
-
-class SObj_SimpleClassField(StorageObj):
-    '''
-    @ClassField attr1 int
-    @ClassField mydict dict <<key:str>,value:double>
-    @ClassField attr3 double
-    '''
-
-
-class SObj_ComplexClassField(StorageObj):
-    '''
-    @ClassField attr1 int
-    @ClassField mydict dict <<key:str>,state:tests.withcassandra.storagedict_split_tests.SObj_Basic>
-    @ClassField attr3 double
-    '''
-
 
 class StorageDictSplitTest(unittest.TestCase):
 
     def test_simple_iterkeys_split_test(self):
+        from hecuba import config
+        from hecuba.hdict import StorageDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.tab30")
         config.session.execute(
             "CREATE TABLE IF NOT EXISTS my_app.tab30(position int, value text, PRIMARY KEY(position))")
@@ -74,6 +37,9 @@ class StorageDictSplitTest(unittest.TestCase):
         self.assertEqual(what_should_be, res)
 
     def test_remote_build_iterkeys_split_test(self):
+        from hecuba import config
+        from hecuba.hdict import StorageDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.tab_b0")
         config.session.execute(
             "CREATE TABLE IF NOT EXISTS my_app.tab_b0(position int, value text, PRIMARY KEY(position))")
@@ -107,6 +73,9 @@ class StorageDictSplitTest(unittest.TestCase):
         self.assertEqual(what_should_be, res)
 
     def test_composed_iteritems_test(self):
+        from hecuba import config
+        from hecuba.hdict import StorageDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.tab_b1")
         config.session.execute(
             "CREATE TABLE IF NOT EXISTS my_app.tab_b1(pid int,time int, value text,x float,y float,z float, PRIMARY KEY(pid,time))")
@@ -144,6 +113,7 @@ class StorageDictSplitTest(unittest.TestCase):
             self.assertAlmostEquals(a[3], b.z, delta=delta)
 
     def computeItems(self, SDict):
+
         expected = len(SDict)
         counter = 0
         for item in SDict.iterkeys():
@@ -152,6 +122,9 @@ class StorageDictSplitTest(unittest.TestCase):
         return counter
 
     def testSplitTypeSpecBasic(self):
+        from hecuba import config
+        from class_definitions import SDict_SimpleTypeSpec
+
         config.session.execute("DROP TABLE IF EXISTS my_app.test_records")
         nitems = 1000
         mybook = SDict_SimpleTypeSpec("test_records")
@@ -177,6 +150,8 @@ class StorageDictSplitTest(unittest.TestCase):
         self.assertEqual(acc, nitems)
 
     def testSplitTypeSpecComplex(self):
+        from hecuba import config
+        from class_definitions import SObj_Basic, SDict_ComplexTypeSpec
         config.session.execute("DROP TABLE IF EXISTS my_app.experimentx")
         nitems = 10
         mybook = SDict_ComplexTypeSpec("experimentx")
@@ -205,6 +180,9 @@ class StorageDictSplitTest(unittest.TestCase):
         self.assertEqual(acc, nitems)
 
     def testSplitClassFieldSimple(self):
+        from hecuba import config
+        from class_definitions import SObj_SimpleClassField
+
         config.session.execute("DROP TABLE IF EXISTS my_app.so_split_dict_simple")
         nitems = 80
         mybook = SObj_SimpleClassField("so_split_dict_simple")
@@ -233,8 +211,11 @@ class StorageDictSplitTest(unittest.TestCase):
         self.assertEqual(acc, nitems)
 
     def testSplitClassFieldComplex(self):
+        from hecuba import config
+        from class_definitions import SObj_ComplexClassField, SObj_Basic
+
         config.session.execute("DROP TABLE IF EXISTS my_app.so_split_dict_complex")
-        nitems = 250
+        nitems = 100
         mybook = SObj_ComplexClassField("so_split_dict_complex")
         mybook.attr1 = nitems
         mybook.attr3 = nitems / 100

--- a/tests/withcassandra/storagedict_tests.py
+++ b/tests/withcassandra/storagedict_tests.py
@@ -1,45 +1,12 @@
 import unittest
 
-from hecuba import config, StorageObj, StorageDict
-from app.words import Words
-import uuid
-import time
-
-
-class MyStorageDict(StorageDict):
-    '''
-    @TypeSpec <<position:int>,val:int>
-    '''
-    pass
-
-
-class MyStorageDict2(StorageDict):
-    '''
-    @TypeSpec <<position:int, position2:str>,val:int>
-    '''
-    pass
-
-
-class MyStorageDict3(StorageDict):
-    '''
-    @TypeSpec <<str>,int>
-    '''
-
-
-class MyStorageObjC(StorageObj):
-    '''
-    @ClassField mona dict<<a:str>,b:int>
-    '''
-
-
-class MyStorageDictA(StorageDict):
-    '''
-    @TypeSpec <<a:str>,b:int>
-    '''
-
 
 class StorageDictTest(unittest.TestCase):
     def test_init_empty(self):
+        import uuid
+        from hecuba import config
+        from hecuba import StorageDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.tab1")
         tablename = "ksp.tab1"
         tokens = [(1l, 2l), (2l, 3l), (3l, 4l)]
@@ -66,6 +33,10 @@ class StorageDictTest(unittest.TestCase):
         self.assertEqual(nopars._is_persistent, rebuild._is_persistent)
 
     def test_init_empty_def_keyspace(self):
+        import uuid
+        from hecuba import config
+        from hecuba import StorageDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.tab1")
         tablename = "tab1"
         tokens = [(1l, 2l), (2l, 3l), (3l, 4l)]
@@ -92,6 +63,9 @@ class StorageDictTest(unittest.TestCase):
         self.assertEqual(nopars._is_persistent, rebuild._is_persistent)
 
     def test_simple_insertions(self):
+        from hecuba import config
+        from hecuba import StorageDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.tab10")
         tablename = "tab10"
         tokens = [(1l, 2l), (2l, 3l), (3l, 4l)]
@@ -107,6 +81,9 @@ class StorageDictTest(unittest.TestCase):
         self.assertEqual(count, 100)
 
     def test_dict_print(self):
+        from hecuba import config
+        from hecuba import StorageDict
+
         tablename = "tab10"
         config.session.execute("DROP TABLE IF EXISTS my_app." + tablename)
         pd = StorageDict(tablename,
@@ -126,6 +103,9 @@ class StorageDictTest(unittest.TestCase):
         self.assertEquals(pd.__repr__().count(':'), 1000)
 
     def test_get_strs(self):
+        from hecuba import config
+        from hecuba import StorageDict
+
         tablename = "tab10"
         config.session.execute("DROP TABLE IF EXISTS my_app." + tablename)
         pd = StorageDict(tablename,
@@ -150,6 +130,9 @@ class StorageDictTest(unittest.TestCase):
         '''
 
     def test_make_persistent(self):
+        from hecuba import config
+        from class_definitions import Words
+
         config.session.execute("DROP TABLE IF EXISTS my_app.t_make_words")
         nopars = Words()
         self.assertFalse(nopars._is_persistent)
@@ -173,6 +156,9 @@ class StorageDictTest(unittest.TestCase):
 
 
     def test_none_value(self):
+        from hecuba import config
+        from class_definitions import MyStorageDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.somename")
         mydict = MyStorageDict('somename')
         mydict[0]=None
@@ -181,6 +167,9 @@ class StorageDictTest(unittest.TestCase):
 
 
     def test_none_keys(self):
+        from hecuba import config
+        from class_definitions import MyStorageDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.somename")
         mydict = MyStorageDict('somename')
         def set_none_key():
@@ -192,6 +181,9 @@ class StorageDictTest(unittest.TestCase):
 
 
     def test_paranoid_setitem_nonpersistent(self):
+        from hecuba import config
+        from hecuba import StorageDict
+
         config.hecuba_type_checking = True
         pd = StorageDict(None,
                          [('position', 'int')],
@@ -211,6 +203,9 @@ class StorageDictTest(unittest.TestCase):
         config.hecuba_type_checking = False
 
     def test_paranoid_setitem_multiple_nonpersistent(self):
+        from hecuba import config
+        from hecuba import StorageDict
+
         config.hecuba_type_checking = True
         pd = StorageDict(None,
                          [('position1', 'int'), ('position2', 'text')],
@@ -230,6 +225,9 @@ class StorageDictTest(unittest.TestCase):
         config.hecuba_type_checking = False
 
     def test_paranoid_setitem_persistent(self):
+        from hecuba import config
+        from hecuba import StorageDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.tab_a1")
         config.hecuba_type_checking = True
         pd = StorageDict("tab_a1",
@@ -247,6 +245,9 @@ class StorageDictTest(unittest.TestCase):
         config.hecuba_type_checking = False
 
     def test_paranoid_setitem_multiple_persistent(self):
+        from hecuba import config
+        from hecuba import StorageDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.tab_a2")
         config.hecuba_type_checking = True
         pd = StorageDict("tab_a2",
@@ -269,6 +270,9 @@ class StorageDictTest(unittest.TestCase):
         config.hecuba_type_checking = False
 
     def test_paranoid_setitemdouble_persistent(self):
+        from hecuba import config
+        from hecuba import StorageDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.tab_a3")
         config.hecuba_type_checking = True
         pd = StorageDict("tab_a3",
@@ -286,6 +290,10 @@ class StorageDictTest(unittest.TestCase):
         config.hecuba_type_checking = False
 
     def test_paranoid_setitemdouble_multiple_persistent(self):
+        import time
+        from hecuba import config
+        from hecuba import StorageDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.tab_a4")
         config.hecuba_type_checking = True
         pd = StorageDict("tab_a4",
@@ -297,9 +305,11 @@ class StorageDictTest(unittest.TestCase):
         config.hecuba_type_checking = False
 
     def test_empty_persistent(self):
+        from hecuba import config
+        from class_definitions import Words
+
         config.session.execute("DROP TABLE IF EXISTS my_app.wordsso_words")
         config.session.execute("DROP TABLE IF EXISTS my_app.wordsso")
-        from app.words import Words
         so = Words()
         so.make_persistent("wordsso")
         so.ciao = "an attribute"
@@ -321,6 +331,9 @@ class StorageDictTest(unittest.TestCase):
         self.assertEqual(0, count)
 
     def test_simple_iteritems_test(self):
+        from hecuba import config
+        from hecuba import StorageDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.tab_a1")
 
         pd = StorageDict("tab_a1",
@@ -346,6 +359,9 @@ class StorageDictTest(unittest.TestCase):
         self.assertEqual(what_should_be, res)
 
     def test_simple_itervalues_test(self):
+        from hecuba import config
+        from hecuba import StorageDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.tab_a2")
         tablename = "tab_a2"
         pd = StorageDict(tablename,
@@ -373,6 +389,9 @@ class StorageDictTest(unittest.TestCase):
         self.assertEqual(what_should_be, res)
 
     def test_simple_iterkeys_test(self):
+        from hecuba import config
+        from hecuba import StorageDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.tab_a3")
         tablename = "tab_a3"
         pd = StorageDict(tablename,
@@ -398,6 +417,9 @@ class StorageDictTest(unittest.TestCase):
         self.assertEqual(what_should_be, res)
 
     def test_simple_contains(self):
+        from hecuba import config
+        from hecuba import StorageDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.tab_a4")
         tablename = "tab_a4"
         pd = StorageDict(tablename,
@@ -417,6 +439,9 @@ class StorageDictTest(unittest.TestCase):
             self.assertTrue(i in pd)
 
     def test_deleteitem_nonpersistent(self):
+        from hecuba import config
+        from hecuba import StorageDict
+
         pd = StorageDict(None,
                          [('position', 'int')],
                          [('value', 'text')])
@@ -440,6 +465,9 @@ class StorageDictTest(unittest.TestCase):
         self.assertRaises(KeyError, del_val)
 
     def test_deleteitem_persistent(self):
+        from hecuba import config
+        from hecuba import StorageDict
+
         tablename = "tab_a5"
         config.session.execute("DROP TABLE IF EXISTS my_app." + tablename)
         pd = StorageDict(tablename,
@@ -467,6 +495,9 @@ class StorageDictTest(unittest.TestCase):
         self.assertRaises(KeyError, del_val)
 
     def test_composed_iteritems_test(self):
+        from hecuba import config
+        from hecuba import StorageDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.tab12")
         tablename = "tab12"
         pd = StorageDict(tablename,
@@ -501,6 +532,9 @@ class StorageDictTest(unittest.TestCase):
             self.assertAlmostEquals(a[3], b.z, delta=delta)
 
     def test_composed_key_return_list_iteritems_test(self):
+        from hecuba import config
+        from hecuba import StorageDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.tab13")
         tablename = "tab13"
         pd = StorageDict(tablename,
@@ -534,6 +568,9 @@ class StorageDictTest(unittest.TestCase):
         self.assertEqual(data, data2)
 
     def test_storagedict_newinterface_localmemory(self):
+        from hecuba import config
+        from class_definitions import MyStorageDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.my_dict")
 
         my_dict = MyStorageDict()
@@ -546,6 +583,9 @@ class StorageDictTest(unittest.TestCase):
         self.assertEquals(True, error)
 
     def test_storagedict_newinterface_memorytopersistent(self):
+        from hecuba import config
+        from class_definitions import MyStorageDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.my_dict")
 
         my_dict = MyStorageDict()
@@ -565,6 +605,10 @@ class StorageDictTest(unittest.TestCase):
         self.assertEquals(1, count)
 
     def test_storagedict_newinterface_persistent(self):
+        import time
+        from hecuba import config
+        from class_definitions import MyStorageDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.my_dict")
 
         my_dict = MyStorageDict()
@@ -584,6 +628,10 @@ class StorageDictTest(unittest.TestCase):
         self.assertEquals(2, my_dict2[1])
 
     def test_update(self):
+        import time
+        from hecuba import config
+        from hecuba import StorageDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.tab_a4")
         config.session.execute("DROP TABLE IF EXISTS my_app.tab_a5")
         tablename = "tab_a4"
@@ -616,6 +664,10 @@ class StorageDictTest(unittest.TestCase):
         self.assertEquals(pd[4], 'final_4')
 
     def test_update_kwargs(self):
+        import time
+        from hecuba import config
+        from hecuba import StorageDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.tab_a6")
         tablename = "tab_a6"
         pd = StorageDict(tablename,
@@ -632,6 +684,10 @@ class StorageDictTest(unittest.TestCase):
         self.assertEquals(pd['val2'], 'new_b')
 
     def test_get_persistent(self):
+        import time
+        from hecuba import config
+        from class_definitions import MyStorageDict3
+
         table_name = 'tab_a7'
         config.session.execute("DROP TABLE IF EXISTS my_app." + table_name)
         my_text = MyStorageDict3('my_app.' + table_name)
@@ -641,6 +697,9 @@ class StorageDictTest(unittest.TestCase):
         self.assertEquals(1, my_text.get('word', 0))
 
     def test_get_notpersistent(self):
+        import time
+        from class_definitions import MyStorageDict3
+
         my_text = MyStorageDict3()
         self.assertEquals(0, my_text.get('word', 0))
         my_text['word'] = my_text.get('word', 0) + 1
@@ -648,6 +707,9 @@ class StorageDictTest(unittest.TestCase):
         self.assertEquals(1, my_text.get('word', 0))
 
     def test_keys(self):
+        from hecuba import config
+        from class_definitions import MyStorageDict2
+
         config.session.execute("DROP TABLE IF EXISTS my_app.test_keys")
         my_dict = MyStorageDict2('test_keys')
         # int,text - int
@@ -695,6 +757,9 @@ class StorageDictTest(unittest.TestCase):
         config.session.execute("DROP TABLE IF EXISTS my_app.test_keys")
 
     def test_values(self):
+        from hecuba import config
+        from class_definitions import MyStorageDict2
+
         config.session.execute("DROP TABLE IF EXISTS my_app.test_values")
         my_dict = MyStorageDict2('test_values')
         # int,text - int
@@ -742,6 +807,9 @@ class StorageDictTest(unittest.TestCase):
         config.session.execute("DROP TABLE IF EXISTS my_app.test_values")
 
     def test_items(self):
+        from hecuba import config
+        from class_definitions import MyStorageDict2
+
         config.session.execute("DROP TABLE IF EXISTS my_app.test_items")
         my_dict = MyStorageDict2('test_items')
         # int,text - int
@@ -792,6 +860,9 @@ class StorageDictTest(unittest.TestCase):
         '''
         check that the prefetch returns the exact same number of elements as inserted 
         '''
+        from hecuba import config
+        from class_definitions import MyStorageDict2
+
         config.session.execute("DROP TABLE IF EXISTS my_app.test_iterator_sync")
         my_dict = MyStorageDict2('test_iterator_sync')
         # int,text - int
@@ -811,6 +882,9 @@ class StorageDictTest(unittest.TestCase):
         config.session.execute("DROP TABLE IF EXISTS my_app.test_iterator_sync")
 
     def test_assign_and_replace(self):
+        from hecuba import config
+        from class_definitions import MyStorageObjC, MyStorageDictA
+
         config.session.execute("DROP TABLE IF EXISTS my_app.first_name")
         config.session.execute("DROP TABLE IF EXISTS my_app.first_name_mona")
         config.session.execute("DROP TABLE IF EXISTS my_app.second_name")

--- a/tests/withcassandra/storageobj_split_tests.py
+++ b/tests/withcassandra/storageobj_split_tests.py
@@ -1,18 +1,11 @@
 import unittest
 
-from hecuba import config
-from hecuba.storageobj import StorageObj
-
-
-class TestSimple(StorageObj):
-    '''
-    @ClassField words dict<<position:int>,value:str>
-    '''
-    pass
-
 
 class StorageObjSplitTest(unittest.TestCase):
     def test_simple_iterkeys_split_test(self):
+        from hecuba import config
+        from class_definitions import TestSimple
+
         tablename = "tab30"
         config.session.execute("DROP TABLE IF EXISTS my_app." + tablename)
         config.session.execute("DROP TABLE IF EXISTS my_app." + tablename + "_words")
@@ -44,6 +37,9 @@ class StorageObjSplitTest(unittest.TestCase):
         self.assertEqual(what_should_be, res)
 
     def test_build_remotely_iterkeys_split_test(self):
+        from hecuba import config
+        from class_definitions import TestSimple
+
         tablename = 'tab30'
         config.session.execute('DROP TABLE IF EXISTS my_app.' + tablename)
         config.session.execute('DROP TABLE IF EXISTS my_app.' + tablename + '_words')
@@ -79,6 +75,9 @@ class StorageObjSplitTest(unittest.TestCase):
         self.assertEqual(what_should_be, res)
 
     def test_simple_iterkeys_split_fromSO_test(self):
+        from hecuba import config
+        from class_definitions import TestSimple
+
         tablename = "tab31"
         config.session.execute("DROP TABLE IF EXISTS my_app." + tablename)
         config.session.execute("DROP TABLE IF EXISTS my_app." + tablename + "_words")
@@ -108,6 +107,9 @@ class StorageObjSplitTest(unittest.TestCase):
         self.assertEqual(what_should_be, res)
 
     def test_build_remotely_iterkeys_split_fromSO_test(self):
+        from hecuba import config
+        from class_definitions import TestSimple
+
         tablename = "tab32"
         config.session.execute("DROP TABLE IF EXISTS my_app." + tablename)
         config.session.execute("DROP TABLE IF EXISTS my_app." + tablename + "_words")
@@ -140,6 +142,9 @@ class StorageObjSplitTest(unittest.TestCase):
         self.assertEqual(what_should_be, res)
 
     def test_split_with_different_storage_ids(self):
+        from hecuba import config
+        from class_definitions import TestSimple
+
         tablename = "tab32"
         config.session.execute("DROP TABLE IF EXISTS my_app." + tablename)
         config.session.execute("DROP TABLE IF EXISTS my_app." + tablename + "_words")

--- a/tests/withcassandra/storageobj_tests.py
+++ b/tests/withcassandra/storageobj_tests.py
@@ -1,144 +1,13 @@
 import unittest
-import uuid
-import time
-from hecuba.IStorage import IStorage
-from app.words import Words
-from hecuba import config
-from hecuba.storageobj import StorageObj
-import cassandra
-from storage.api import getByID
-import numpy as np
-
-
-class Result(StorageObj):
-    '''
-    @ClassField instances dict<<word:str>,numinstances:int>
-    '''
-    pass
-
-
-class TestStorageObj(StorageObj):
-    '''
-       @ClassField test dict<<position:int>,text:str>
-    '''
-    pass
-
-
-class TestStorageIndexedArgsObj(StorageObj):
-    '''
-       @ClassField test dict<<position:int>,x:float,y:float,z:float>
-       @Index_on test x,y,z
-    '''
-    pass
-
-
-class Test2StorageObj(StorageObj):
-    '''
-       @ClassField name str
-       @ClassField age int
-    '''
-    pass
-
-
-class Test2StorageObjFloat(StorageObj):
-    '''
-       @ClassField name str
-       @ClassField age float
-    '''
-    pass
-
-
-class Test3StorageObj(StorageObj):
-    '''
-       @ClassField myso tests.withcassandra.storageobj_tests.Test2StorageObj
-       @ClassField myso2 tests.withcassandra.storageobj_tests.TestStorageObj
-       @ClassField myint int
-       @ClassField mystr str
-    '''
-    pass
-
-
-class Test4StorageObj(StorageObj):
-    '''
-       @ClassField myotherso tests.withcassandra.storageobj_tests.Test2StorageObj
-    '''
-    pass
-
-
-class Test4bStorageObj(StorageObj):
-    '''
-       @ClassField myotherso tests.withcassandra.test2storageobj.Test2StorageObj
-    '''
-    pass
-
-
-class Test5StorageObj(StorageObj):
-    '''
-       @ClassField test2 dict<<position:int>,myso:tests.withcassandra.storageobj_tests.Test2StorageObj>
-    '''
-    pass
-
-
-class Test6StorageObj(StorageObj):
-    '''
-       @ClassField test3 dict<<int>,str,str>
-    '''
-    pass
-
-
-class Test7StorageObj(StorageObj):
-    '''
-       @ClassField test2 dict<<int>,tests.withcassandra.storageobj_tests.Test2StorageObj>
-    '''
-    pass
-
-
-class TestStorageObjNumpy(StorageObj):
-    '''
-       @ClassField mynumpy numpy.ndarray
-    '''
-    pass
-
-
-class TestStorageObjNumpyDict(StorageObj):
-    '''
-       @ClassField mynumpydict dict<<int>,numpy.ndarray>
-    '''
-    pass
-
-
-
-class TestAttributes(StorageObj):
-    '''
-       @ClassField key int
-    '''
-
-    value = None
-
-    def do_nothing_at_all(self):
-        pass
-
-    def setvalue(self, v):
-        self.value = v
-
-    def getvalue(self):
-        return self.value
-
-class mixObj(StorageObj):
-    '''
-    @ClassField floatfield float
-    @ClassField intField int
-    @ClassField strField str
-    @ClassField intlistField list <int>
-    @ClassField floatlistField list <float>
-    @ClassField strlistField list <str>
-    @ClassField dictField dict <<int>,str>
-    @ClassField inttupleField tuple <int, int>
-    '''
 
 
 class StorageObjTest(unittest.TestCase):
     def test_build_remotely(self):
+        import uuid
+        from hecuba.IStorage import IStorage
+        from hecuba import config
+        from hecuba.storageobj import StorageObj
+        from class_definitions import TestStorageObj
 
         class res:
             pass
@@ -164,6 +33,13 @@ class StorageObjTest(unittest.TestCase):
         self.assertEqual(tkns, r.tokens)
 
     def test_init_create_pdict(self):
+        import uuid
+        from hecuba.IStorage import IStorage
+        from hecuba import config
+        from hecuba.storageobj import StorageObj
+
+        from class_definitions import TestStorageObj, Result
+
         config.session.execute("DROP TABLE IF EXISTS my_app.tt1")
         config.session.execute("DROP TABLE IF EXISTS my_app.tt1_instances")
 
@@ -208,6 +84,9 @@ class StorageObjTest(unittest.TestCase):
         self.assertEqual(tkns, read_tkns)
 
     def test_mixed_class(self):
+        from hecuba import config
+        from class_definitions import mixObj
+
         config.session.execute("DROP TABLE IF EXISTS hecuba_test.bla")
         myObj = mixObj()
 
@@ -240,6 +119,10 @@ class StorageObjTest(unittest.TestCase):
         self.assertEquals(inttupleField, myObj.inttupleField)
 
     def test_init_empty(self):
+        from hecuba import config
+        from hecuba.storageobj import StorageObj
+        from class_definitions import TestStorageObj
+
         config.session.execute("DROP TABLE IF EXISTS ksp1.ttta")
         nopars = TestStorageObj('ksp1.ttta')
         self.assertEqual('ttta', nopars._table)
@@ -263,6 +146,12 @@ class StorageObjTest(unittest.TestCase):
         # self.assertEqual(vars(nopars), vars(rebuild))
 
     def test_make_persistent(self):
+        import time
+        from class_definitions import Words
+        from hecuba import config
+
+        from class_definitions import Test6StorageObj
+
         config.session.execute("DROP TABLE IF EXISTS hecuba_test.wordsso")
         config.session.execute("DROP TABLE IF EXISTS hecuba_test.nonames")
         config.session.execute("DROP TABLE IF EXISTS hecuba_test.words")
@@ -301,9 +190,12 @@ class StorageObjTest(unittest.TestCase):
         self.assertEqual('2', rval1)
 
     def test_empty_persistent(self):
+        from hecuba import config
+        from class_definitions import Words
+
         config.session.execute("DROP TABLE IF EXISTS my_app.wordsso_words")
         config.session.execute("DROP TABLE IF EXISTS my_app.wordsso")
-        from app.words import Words
+
         so = Words()
         so.make_persistent("wordsso")
         so.ciao = "an attribute"
@@ -325,6 +217,9 @@ class StorageObjTest(unittest.TestCase):
         self.assertEqual(0, count)
 
     def test_simple_stores_after_make_persistent(self):
+        from hecuba import config
+        from class_definitions import Test2StorageObj
+
         config.session.execute("DROP TABLE IF EXISTS my_app.t2")
         so = Test2StorageObj()
         so.name = 'caio'
@@ -336,6 +231,9 @@ class StorageObjTest(unittest.TestCase):
         self.assertEqual(so.age, 1000)
 
     def test_simple_attributes(self):
+        from hecuba import config
+        from class_definitions import Test2StorageObj
+
         config.session.execute("DROP TABLE IF EXISTS my_app.t2")
         so = Test2StorageObj()
         so.make_persistent("t2")
@@ -347,6 +245,9 @@ class StorageObjTest(unittest.TestCase):
         self.assertEqual(so.age, 1000)
 
     def test_modify_simple_attributes(self):
+        from hecuba import config
+        from class_definitions import Test2StorageObj
+
         config.session.execute("DROP TABLE IF EXISTS my_app.t2")
         so = Test2StorageObj()
         so.make_persistent("t2")
@@ -362,6 +263,8 @@ class StorageObjTest(unittest.TestCase):
         self.assertEqual(so.age, 2000)
 
     def test_delattr_nonpersistent(self):
+        from class_definitions import Test2StorageObj
+
         so = Test2StorageObj()
         so.name = 'caio'
         del so.name
@@ -372,6 +275,9 @@ class StorageObjTest(unittest.TestCase):
         self.assertRaises(AttributeError, del_attr)
 
     def test_delattr_persistent(self):
+        from hecuba import config
+        from class_definitions import Test2StorageObj
+
         config.session.execute("DROP TABLE IF EXISTS my_app.t3")
         so = Test2StorageObj("t3")
         so.name = 'caio'
@@ -388,6 +294,9 @@ class StorageObjTest(unittest.TestCase):
         self.assertRaises(AttributeError, del_attr1)
 
     def test_delattr_persistent_nested(self):
+        from hecuba import config
+        from class_definitions import Test3StorageObj, Test2StorageObj
+
         config.session.execute("DROP TABLE IF EXISTS my_app.t4")
         so = Test3StorageObj("t4")
         nestedSo = Test2StorageObj()
@@ -422,6 +331,9 @@ class StorageObjTest(unittest.TestCase):
 
 
     def test_modify_simple_before_mkp_attributes(self):
+        from hecuba import config
+        from class_definitions import Test2StorageObj
+
         config.session.execute("DROP TABLE IF EXISTS my_app.t2")
         so = Test2StorageObj()
         so.name = 'caio'
@@ -437,6 +349,9 @@ class StorageObjTest(unittest.TestCase):
         self.assertEqual(so.age, 2000)
 
     def test_paranoid_setattr_nonpersistent(self):
+        from hecuba import config
+        from class_definitions import Test2StorageObj
+
         config.hecuba_type_checking = True
         config.session.execute("DROP TABLE IF EXISTS my_app.t2")
         so = Test2StorageObj()
@@ -457,6 +372,9 @@ class StorageObjTest(unittest.TestCase):
         config.hecuba_type_checking = False
 
     def test_paranoid_setattr_persistent(self):
+        from hecuba import config
+        from class_definitions import Test2StorageObj
+
         config.session.execute("DROP TABLE IF EXISTS my_app.t2")
         config.hecuba_type_checking = True
         so = Test2StorageObj("t2")
@@ -483,6 +401,9 @@ class StorageObjTest(unittest.TestCase):
         config.hecuba_type_checking = False
 
     def test_paranoid_setattr_float(self):
+        from hecuba import config
+        from class_definitions import Test2StorageObjFloat
+
         config.hecuba_type_checking = True
         config.session.execute("DROP TABLE IF EXISTS my_app.t2")
         so = Test2StorageObjFloat("t2")
@@ -490,6 +411,11 @@ class StorageObjTest(unittest.TestCase):
         config.hecuba_type_checking = False
 
     def test_nestedso_notpersistent(self):
+        import cassandra
+        from storage.api import getByID
+        from hecuba import config
+        from class_definitions import Test3StorageObj, Test4StorageObj, Test4bStorageObj
+
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso")
         config.session.execute("DROP TABLE IF EXISTS my_app.myso")
 
@@ -542,6 +468,10 @@ class StorageObjTest(unittest.TestCase):
         self.assertEquals('bla', query_res.name)
 
     def test_nestedso_persistent(self):
+        from hecuba import config
+        import cassandra
+        from class_definitions import Test3StorageObj
+
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso")
         config.session.execute("DROP TABLE IF EXISTS my_app.myso")
 
@@ -567,6 +497,10 @@ class StorageObjTest(unittest.TestCase):
         self.assertEquals('position0', my_nested_so.myso2.name)
 
     def test_nestedso_topersistent(self):
+        from hecuba import config
+        import cassandra
+        from class_definitions import Test3StorageObj
+
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso")
         config.session.execute("DROP TABLE IF EXISTS my_app.myso")
 
@@ -597,6 +531,10 @@ class StorageObjTest(unittest.TestCase):
         self.assertEquals('Link', query_res.name)
 
     def test_nestedso_sets_gets(self):
+        from hecuba import config
+        import cassandra
+        from class_definitions import Test3StorageObj
+
         config.session.execute("DROP TABLE IF EXISTS my_app.myso")
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso")
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso_myso")
@@ -647,6 +585,11 @@ class StorageObjTest(unittest.TestCase):
         self.assertEquals(True, error)
 
     def test_nestedso_sets_gets_complex(self):
+        from hecuba import config
+        import cassandra
+        import time
+        from class_definitions import Test3StorageObj
+
         config.session.execute("DROP TABLE IF EXISTS my_app.tnsgc_myso2")
         config.session.execute("DROP TABLE IF EXISTS my_app.tnsgc_myso2_test")
 
@@ -675,6 +618,10 @@ class StorageObjTest(unittest.TestCase):
         self.assertEquals(100, count)
 
     def test_nestedso_deletepersistent(self):
+        from hecuba import config
+        import cassandra
+        from class_definitions import Test3StorageObj
+
         config.session.execute("DROP TABLE IF EXISTS my_app.tndp")
         config.session.execute("DROP TABLE IF EXISTS my_app.tndp_myso")
         config.session.execute("DROP TABLE IF EXISTS my_app.tndp_myso2")
@@ -698,6 +645,9 @@ class StorageObjTest(unittest.TestCase):
         self.assertEquals(0, entries)
 
     def test_nestedso_dictofsos(self):
+        from hecuba import config
+        from class_definitions import Test5StorageObj, Test2StorageObj
+
         config.session.execute("DROP TABLE IF EXISTS my_app.topstorageobj")
         config.session.execute("DROP TABLE IF EXISTS my_app.topstorageobj_test2")
         my_nested_so = Test5StorageObj()
@@ -718,6 +668,9 @@ class StorageObjTest(unittest.TestCase):
         used as an attribute in Test7StorageObj has the form <int,StorageObj> where no name has been given for the
         StorageObj nor the Integer. In this case, a default name is used (key0,val0).
         '''
+        from hecuba import config
+        from class_definitions import Test7StorageObj, Test2StorageObj
+
         config.session.execute("DROP TABLE IF EXISTS my_app.topstorageobj2")
         config.session.execute("DROP TABLE IF EXISTS my_app.topstorageobj2_test2")
         config.session.execute("DROP TABLE IF EXISTS my_app.topstorageobj2_test2_val0")
@@ -736,6 +689,9 @@ class StorageObjTest(unittest.TestCase):
 
 
     def test_nestedso_retrievedata(self):
+        from hecuba import config
+        from class_definitions import Test5StorageObj, Test2StorageObj
+
         config.session.execute("DROP TABLE IF EXISTS my_app.tnr")
         config.session.execute("DROP TABLE IF EXISTS my_app.tnr_test2")
 
@@ -758,12 +714,19 @@ class StorageObjTest(unittest.TestCase):
         self.assertEquals(10, my_nested_so2.test2[0].age)
 
     def test_numpy_persistent(self):
+        from hecuba import config
+        from class_definitions import TestStorageObjNumpy
+
         config.session.execute("DROP TABLE IF EXISTS my_app.tnp")
         config.session.execute("DROP TABLE IF EXISTS my_app.tnp_mynumpy")
         config.session.execute("DROP TABLE IF EXISTS my_app.tnp_mynumpy_numpies")
         my_so = TestStorageObjNumpy('tnp')
 
     def test_numpy_set(self):
+        import numpy as np
+        from hecuba import config
+        from class_definitions import TestStorageObjNumpy
+
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso")
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso_mynumpy")
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso_mynumpy_numpies")
@@ -772,6 +735,10 @@ class StorageObjTest(unittest.TestCase):
         my_so.make_persistent('mynewso')
 
     def test_numpy_get(self):
+        import numpy as np
+        from hecuba import config
+        from class_definitions import TestStorageObjNumpy
+
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso")
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso_mynumpy")
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso_mynumpy_numpies")
@@ -783,6 +750,10 @@ class StorageObjTest(unittest.TestCase):
         self.assertTrue(np.array_equal(mynumpy, my_so.mynumpy))
 
     def test_numpy_topersistent(self):
+        import numpy as np
+        from hecuba import config
+        from class_definitions import TestStorageObjNumpy
+
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso")
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso_mynumpy")
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso_mynumpy_numpies")
@@ -791,12 +762,19 @@ class StorageObjTest(unittest.TestCase):
         my_so.make_persistent('mynewso')
 
     def test_numpydict_persistent(self):
+        from hecuba import config
+        from class_definitions import TestStorageObjNumpyDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso")
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso_mynumpydict")
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso_mynumpydict_numpies")
         my_so = TestStorageObjNumpyDict('mynewso')
 
     def test_numpydict_set(self):
+        import numpy as np
+        from hecuba import config
+        from class_definitions import TestStorageObjNumpyDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso")
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso_mynumpydict")
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso_mynumpydict_numpies")
@@ -804,6 +782,10 @@ class StorageObjTest(unittest.TestCase):
         my_so.mynumpydict[0] = np.random.rand(3, 2)
 
     def test_numpydict_to_persistent(self):
+        import numpy as np
+        from hecuba import config
+        from class_definitions import TestStorageObjNumpyDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso")
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso_mynumpydict")
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso_mynumpydict_numpies")
@@ -812,6 +794,10 @@ class StorageObjTest(unittest.TestCase):
         my_so.make_persistent('mynewso')
 
     def test_numpydict_get(self):
+        import numpy as np
+        from hecuba import config
+        from class_definitions import TestStorageObjNumpyDict
+
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso")
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso_mynumpydict")
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso_mynumpydict_numpies")
@@ -826,6 +812,11 @@ class StorageObjTest(unittest.TestCase):
 
 
     def test_numpy_operations(self):
+        from hecuba import config
+        from class_definitions import TestStorageObjNumpy
+        import numpy as np
+        import time
+
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso")
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso_mynumpy")
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso_mynumpy_numpies")
@@ -833,7 +824,7 @@ class StorageObjTest(unittest.TestCase):
         base_numpy = np.arange(2048)
         my_so.mynumpy = np.arange(2048)
         my_so.make_persistent('mynewso')
-        import time
+
         time.sleep(2)
         self.assertTrue(np.array_equal(base_numpy, my_so.mynumpy))
         base_numpy+=1
@@ -844,6 +835,11 @@ class StorageObjTest(unittest.TestCase):
 
 
     def test_numpy_ops_persistent(self):
+        from hecuba import config
+        from class_definitions import TestStorageObjNumpy
+        import numpy as np
+        import time
+
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso")
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso_mynumpy")
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso_mynumpy_numpies")
@@ -851,7 +847,6 @@ class StorageObjTest(unittest.TestCase):
         base_numpy = np.arange(2048)
         my_so.mynumpy = np.arange(2048)
         my_so.make_persistent('mynewso')
-        import time
         time.sleep(2)
         self.assertTrue(np.array_equal(base_numpy, my_so.mynumpy))
         base_numpy += 1
@@ -865,6 +860,9 @@ class StorageObjTest(unittest.TestCase):
         self.assertEqual(np.mean(base_numpy), np.mean(reloaded_so.mynumpy))
 
     def test_numpy_reloading(self):
+        from class_definitions import TestStorageObjNumpy
+        import numpy as np
+
         sizea, sizeb = (1000,1000)
         no = TestStorageObjNumpy("my_app.numpy_test_%d_%d" % (sizea, sizeb))
         a = np.ones((sizea, sizeb))
@@ -877,6 +875,9 @@ class StorageObjTest(unittest.TestCase):
 
 
     def test_numpy_reloading_internals(self):
+        from class_definitions import TestStorageObjNumpy
+        import numpy as np
+
         sizea, sizeb = (1000,1000)
         no = TestStorageObjNumpy("my_app.numpy_test_%d_%d" % (sizea, sizeb))
         a = np.ones((sizea, sizeb))
@@ -893,6 +894,9 @@ class StorageObjTest(unittest.TestCase):
         self.assertEqual(initial_name_np, final_name_np)
 
     def test_storagedict_assign(self):
+        from hecuba import config
+        from class_definitions import TestStorageObj
+
         config.hecuba_type_checking = True
         config.session.execute("DROP TABLE IF EXISTS my_app.t2")
         config.session.execute("DROP TABLE IF EXISTS my_app.t2_test")
@@ -914,6 +918,9 @@ class StorageObjTest(unittest.TestCase):
         test that two StorageObjs pointing to the same table work correctly.
         Changing data on one StorageObj is reflected on the other StorageObj.
         '''
+        from hecuba import config
+        from class_definitions import Test2StorageObj
+
         config.session.execute("DROP TABLE IF EXISTS my_app.test")
         so = Test2StorageObj('test')
         so.name = 'Oliver'
@@ -928,6 +935,9 @@ class StorageObjTest(unittest.TestCase):
         config.session.execute("DROP TABLE IF EXISTS my_app.test")
 
     def test_storageobj_coherence_complex1(self):
+        from hecuba import config
+        from class_definitions import Test3StorageObj,Test2StorageObj
+
         config.session.execute("DROP TABLE IF EXISTS my_app.test")
         config.session.execute("DROP TABLE IF EXISTS my_app.test_myso")
         config.session.execute("DROP TABLE IF EXISTS my_app.test_myso_0")
@@ -949,6 +959,9 @@ class StorageObjTest(unittest.TestCase):
 
 
     def test_storageobj_coherence_complex2(self):
+        from hecuba import config
+        from class_definitions import Test3StorageObj,Test2StorageObj
+
         config.session.execute("DROP TABLE IF EXISTS my_app.test")
         config.session.execute("DROP TABLE IF EXISTS my_app.test_myso")
         config.session.execute("DROP TABLE IF EXISTS my_app.test_myso_0")
@@ -985,6 +998,8 @@ class StorageObjTest(unittest.TestCase):
         config.session.execute("DROP TABLE IF EXISTS my_app.test_myso2_test")
 
     def test_get_attr_1(self):
+        from class_definitions import TestAttributes
+
         storage_obj = TestAttributes()
         storage_obj.do_nothing_at_all()
         value = 123
@@ -993,6 +1008,9 @@ class StorageObjTest(unittest.TestCase):
         self.assertEqual(value, returned)
 
     def test_get_attr_2(self):
+        from hecuba import config
+        from class_definitions import TestAttributes
+
         config.session.execute("DROP TABLE IF EXISTS my_app.test_attr")
         storage_obj = TestAttributes()
         storage_obj.do_nothing_at_all()
@@ -1020,6 +1038,8 @@ class StorageObjTest(unittest.TestCase):
 
 
     def test_get_attr_3(self):
+        from hecuba import config
+        from class_definitions import TestAttributes
         # the same as test_get_attr_2 but the object is persistent since the beginning
 
         config.session.execute("DROP TABLE IF EXISTS my_app.test_attr")

--- a/tests/withcassandra/test2storageobj.py
+++ b/tests/withcassandra/test2storageobj.py
@@ -1,9 +1,0 @@
-from hecuba.storageobj import StorageObj
-
-
-class Test2StorageObj(StorageObj):
-    '''
-       @ClassField name str
-       @ClassField age int
-    '''
-    pass


### PR DESCRIPTION
As in the issue #156 explained, tests were not independent. Tests imported objects, modified them internally, and then were reused by other unit tests.

I fixed it by restricting the objects to their specific unit test. Now their scope is the unit test where they are used, after each test they are destroyed by the garbage collector.