### PR TITLE
Fix bug on unordered keys in prefetch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,4 @@ before_install:
   - export PYTHONPATH=/home/travis/.local/lib/python2.7/site-packages/
   - export PYTHONPATH=/home/travis/.local/lib/python2.7/site-packages/
   - java -version
-  - wget http://ftp.cixug.es/apache/cassandra/3.11.2/apache-cassandra-3.11.2-bin.tar.gz && tar -xzf apache-cassandra-3.11.2-bin.tar.gz && apache-cassandra-3.11.2/bin/cassandra & disown
+  - wget http://archive.apache.org/dist/cassandra/3.11.3/apache-cassandra-3.11.3-bin.tar.gz && tar -xzf apache-cassandra-3.11.3-bin.tar.gz && apache-cassandra-3.11.3/bin/cassandra & disown

--- a/hfetch/TableMetadata.cpp
+++ b/hfetch/TableMetadata.cpp
@@ -194,7 +194,10 @@ TableMetadata::TableMetadata(const char *table_name, const char *keyspace_name,
         if (key.empty()) throw ModuleException("Empty key name given on position: " + std::to_string(i));
         keys += "," + key;
         select_where += "AND " + key + "=? ";
-        if (metadatas[key].col_type == CASS_COLUMN_TYPE_PARTITION_KEY) tokens_keys += "," + key;
+        if (metadatas[key].col_type == CASS_COLUMN_TYPE_PARTITION_KEY) {
+            if (!tokens_keys.empty()) tokens_keys += ",";
+            tokens_keys += key;
+        }
     }
     if (tokens_keys.empty()) throw ModuleException("No partition key detected among the keys: " + keys);
 


### PR DESCRIPTION
The cql query created had a wrong format for the partition keys.
Occurred when the keys in the classfield were unordered
compared to the CQL create statement, for instance
by first setting a clustering key before the partition key.