### PR TITLE
StorageObj nested objects names and creation

### DIFF
--- a/hecuba_py/src/IStorage.py
+++ b/hecuba_py/src/IStorage.py
@@ -163,6 +163,9 @@ class IStorage:
             table = name
         return ksp.lower().encode('UTF8'), table.lower().encode('UTF8')
 
+    def _get_istorage_attrs(self, storage_id):
+        return list(config.session.execute(self._select_istorage_meta, [storage_id]))
+
     def _count_name_collision(self, attribute):
         m = re.compile("^%s_%s(_[0-9]+)?$" % (self._table, attribute))
         q = config.session.execute("SELECT table_name FROM  system_schema.tables WHERE keyspace_name = %s",

--- a/hecuba_py/src/storageobj.py
+++ b/hecuba_py/src/storageobj.py
@@ -291,10 +291,13 @@ class StorageObj(object, IStorage):
         """
             Loads the IStorage objects into memory by creating them or retrieving from the backend.
         """
+        attrs = []
         for attribute, value_info in self._persistent_props.iteritems():
             if value_info['type'] not in IStorage._basic_types:
                 # The attribute is an IStorage object
-                getattr(self, attribute, None)
+                attrs.append((attribute, getattr(self, attribute)))
+        for (attr_name, attr) in attrs:
+            setattr(self, attr_name, attr)
 
     def __eq__(self, other):
         return self.__class__ == other.__class__ and self.getID() == other.getID()
@@ -469,13 +472,8 @@ class StorageObj(object, IStorage):
             if count > 1:
                 attr_name += '_' + str(count - 2)
             # Build the IStorage obj
-            sobj_is_new = value is None
             value = self._build_istorage_obj(name=attr_name, tokens=self._build_args.tokens, storage_id=value,
                                              **value_info)
-            if sobj_is_new:
-                # If we built the IStorage for the first time, save the IStorage Obj to the SObj column
-                setattr(self, attribute, value)
-                return value
 
         object.__setattr__(self, attribute, value)
         return value

--- a/hecuba_py/src/storageobj.py
+++ b/hecuba_py/src/storageobj.py
@@ -469,8 +469,13 @@ class StorageObj(object, IStorage):
             if count > 1:
                 attr_name += '_' + str(count - 2)
             # Build the IStorage obj
+            sobj_is_new = value is None
             value = self._build_istorage_obj(name=attr_name, tokens=self._build_args.tokens, storage_id=value,
                                              **value_info)
+            if sobj_is_new:
+                # If we built the IStorage for the first time, save the IStorage Obj to the SObj column
+                setattr(self, attribute, value)
+                return value
 
         object.__setattr__(self, attribute, value)
         return value

--- a/hecuba_py/tests/block_tests.py
+++ b/hecuba_py/tests/block_tests.py
@@ -30,9 +30,9 @@ class BlockTest(unittest.TestCase):
         results.istorage_props = {}
         results.tokens = [(1l, 2l), (2l, 3l), (3l, 4l), (3l, 5l)]
 
-        words_mock_methods = Words._setup_persistent_structs,Words._load_attributes,Words._store_meta
+        words_mock_methods = Words._create_tables, Words._load_attributes, Words._store_meta
 
-        Words._setup_persistent_structs = Mock(return_value=None)
+        Words._create_tables = Mock(return_value=None)
         Words._load_attributes = Mock(return_value=None)
         Words._store_meta = Mock(return_value=None)
 
@@ -42,13 +42,13 @@ class BlockTest(unittest.TestCase):
 
         b = Words.build_remotely(results)
         self.assertIsInstance(b, Words)
-        Words._setup_persistent_structs.assert_called_once()
+        Words._create_tables.assert_called_once()
         Words._load_attributes.assert_called_once()
         Words._store_meta.assert_called_once()
         assert(b._ksp == "ksp1")
         assert (b._table == "tab1")
 
-        Words._setup_persistent_structs,Words._load_attributes,Words._store_meta = words_mock_methods
+        Words._create_tables, Words._load_attributes, Words._store_meta = words_mock_methods
         StorageDict.make_persistent = sdict_mock_methods
 
     def test_iter_and_get_sets(self):

--- a/hecuba_py/tests/withcassandra/storagedict_tests.py
+++ b/hecuba_py/tests/withcassandra/storagedict_tests.py
@@ -812,14 +812,19 @@ class StorageDictTest(unittest.TestCase):
     def test_assign_and_replace(self):
         config.session.execute("DROP TABLE IF EXISTS my_app.first_name")
         config.session.execute("DROP TABLE IF EXISTS my_app.first_name_mona")
+        config.session.execute("DROP TABLE IF EXISTS my_app.first_name_mona_0")
+        config.session.execute("DROP TABLE IF EXISTS my_app.first_name_mona_1")
         config.session.execute("DROP TABLE IF EXISTS my_app.second_name")
 
         first_storagedict = MyStorageDictA()
         my_storageobj = MyStorageObjC("first_name")
         self.assertTrue(my_storageobj.mona._is_persistent)
 
+        # Creates the 'my_app.first_name_mona' table
         my_storageobj.mona['uno'] = 123
+
         # empty dict no persistent assigned to persistent object
+        # creates the 'my_app.first_name_mona_0' table
         my_storageobj.mona = first_storagedict
 
         self.assertTrue(my_storageobj.mona._is_persistent)
@@ -848,6 +853,8 @@ class StorageDictTest(unittest.TestCase):
 
         config.session.execute("DROP TABLE IF EXISTS my_app.first_name")
         config.session.execute("DROP TABLE IF EXISTS my_app.first_name_mona")
+        config.session.execute("DROP TABLE IF EXISTS my_app.first_name_mona_0")
+        config.session.execute("DROP TABLE IF EXISTS my_app.first_name_mona_1")
         config.session.execute("DROP TABLE IF EXISTS my_app.second_name")
 
 

--- a/hecuba_py/tests/withcassandra/storageobj_tests.py
+++ b/hecuba_py/tests/withcassandra/storageobj_tests.py
@@ -1050,26 +1050,150 @@ class StorageObjTest(unittest.TestCase):
 
         config.session.execute("DROP TABLE IF EXISTS my_app.test_attr")
 
-    def test_recreation(self):
+
+    def test_recreation_init(self):
+        """
+        New StorageObj
+        Persistent attributes
+        Made persistent on the constructor.
+        """
         sobj_name = "my_app.test_attr"
         config.session.execute("DROP TABLE IF EXISTS {}".format(sobj_name))
+        attr1 = 'Test1'
+        attr2 = 23
         storage_obj = Test2StorageObj(sobj_name)
-        storage_obj.name = 'Test1'
-        storage_obj.age = 23
+        storage_obj.name = attr1
+        storage_obj.age = attr2
         uuid_sobj = storage_obj.getID()
 
         storage_obj = None
         result_set = iter(config.session.execute("SELECT * FROM hecuba.istorage WHERE storage_id={}".format(uuid_sobj)))
 
-
         try:
             result = result_set.next()
-        except StopIteration as exc:
+        except StopIteration as ex:
             self.fail("StorageObj istorage data was not saved")
 
         self.assertEqual(result.name, sobj_name)
 
-        #TODO FINISH
+        storage_obj = Test2StorageObj(sobj_name)
+
+        self.assertEqual(storage_obj.name, attr1)
+        self.assertEqual(storage_obj.age, attr2)
+
+
+    def test_recreation_init2(self):
+        """
+        New StorageObj
+        Has persistent and volatile attributes
+        Made persistent on the constructor.
+        """
+        sobj_name = "my_app.test_attr"
+        config.session.execute("DROP TABLE IF EXISTS {}".format(sobj_name))
+        attr1 = 'Test1'
+        attr2 = 23
+        storage_obj = Test2StorageObj(sobj_name)
+        storage_obj.name = attr1
+        storage_obj.nonpersistent = attr2
+        uuid_sobj = storage_obj.getID()
+
+        storage_obj = None
+        result_set = iter(config.session.execute("SELECT * FROM hecuba.istorage WHERE storage_id={}".format(uuid_sobj)))
+
+        try:
+            result = result_set.next()
+        except StopIteration as ex:
+            self.fail("StorageObj istorage data was not saved")
+
+        self.assertEqual(result.name, sobj_name)
+
+        storage_obj = Test2StorageObj(sobj_name)
+
+        self.assertEqual(storage_obj.name, attr1)
+
+        with self.assertRaises(AttributeError):
+            attr = storage_obj.age
+
+        with self.assertRaises(AttributeError):
+            attr = storage_obj.nonpersistent
+
+
+
+    def test_recreation_make_pers(self):
+        """
+        New StorageObj
+        Persistent attributes
+        Made persistent with make_persistent.
+        """
+        sobj_name = "my_app.test_attr"
+        config.session.execute("DROP TABLE IF EXISTS {}".format(sobj_name))
+        attr1 = 'Test1'
+        attr2 = 23
+        storage_obj = Test2StorageObj()
+        storage_obj.make_persistent(sobj_name)
+        uuid_sobj = storage_obj.getID()
+
+        storage_obj = None
+        result_set = iter(config.session.execute("SELECT * FROM hecuba.istorage WHERE storage_id={}".format(uuid_sobj)))
+
+        try:
+            result = result_set.next()
+        except StopIteration as ex:
+            self.fail("StorageObj istorage data was not saved")
+
+        self.assertEqual(result.name, sobj_name)
+
+        storage_obj = Test2StorageObj()
+
+        storage_obj.name = attr1
+        storage_obj.volatile = attr2
+
+        storage_obj.make_persistent(sobj_name)
+
+        self.assertEqual(storage_obj.name, attr1)
+        self.assertEqual(storage_obj.volatile, attr2)
+
+        with self.assertRaises(AttributeError):
+            attr = storage_obj.age
+
+
+
+    def test_recreation_make_pers(self):
+        """
+        New StorageObj
+        Persistent attributes
+        Made persistent with make_persistent.
+        """
+        sobj_name = "my_app.test_attr"
+        config.session.execute("DROP TABLE IF EXISTS {}".format(sobj_name))
+        attr1 = 'Test1'
+        attr2 = 23
+        storage_obj = Test2StorageObj()
+        storage_obj.name = attr1
+        storage_obj.volatile = 'Ofcourse'
+        storage_obj.make_persistent(sobj_name)
+        uuid_sobj = storage_obj.getID()
+
+        storage_obj = None
+        result_set = iter(config.session.execute("SELECT * FROM hecuba.istorage WHERE storage_id={}".format(uuid_sobj)))
+
+        try:
+            result = result_set.next()
+        except StopIteration as ex:
+            self.fail("StorageObj istorage data was not saved")
+
+        self.assertEqual(result.name, sobj_name)
+
+        storage_obj = Test2StorageObj()
+        storage_obj.age = attr2
+        storage_obj.make_persistent(sobj_name)
+
+        self.assertEqual(storage_obj.name, attr1)
+        self.assertEqual(storage_obj.age, attr2)
+
+        with self.assertRaises(AttributeError):
+            attr = storage_obj.volatile
+
 
     def test_nested_recreation(self):
         sobj_name = "my_app.test_attr"

--- a/hecuba_py/tests/withcassandra/storageobj_tests.py
+++ b/hecuba_py/tests/withcassandra/storageobj_tests.py
@@ -1158,7 +1158,7 @@ class StorageObjTest(unittest.TestCase):
 
 
 
-    def test_recreation_make_pers(self):
+    def test_recreation_make_pers2(self):
         """
         New StorageObj
         Persistent attributes


### PR DESCRIPTION
Nested IStorage weren't created properly in the StorageObj. The name given to nested IStorage objects was wrong. Sometimes accessing the nested IStorage objects created a new empty object instead of accessing the stored data in Cassandra.

Fixed by:
* The init method properly creates the nested IStorage objects.
* Doing a getattr retrieves the nested IStorage that existed when the make persistent was called. If setattr was called, returns the last IStorage object assigned.
* Calling a setattr of a persistent StorageObj makes persistent the given object.
* Calling make _persistent on a StorageObj, accesses the hecuba.istorage table to retrieve the metadata (tokens and such)
* Added tests to verify the expected behaviour

Fixes #176 for StorageObjects