### PR TITLE
CMake not found raises a comprehensible error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,16 @@ def package_files(directory):
 
 
 def cmake_build():
-    if subprocess.call(["cmake", "-H./hecuba_core", "-B./build"]) != 0:
-        raise EnvironmentError("error calling cmake")
+    try:
+        if subprocess.call(["cmake", "-H./hecuba_core", "-B./build"]) != 0:
+            raise EnvironmentError("error calling cmake")
+    except OSError as e:
+        if e.errno == os.errno.ENOENT:
+        # CMake not found error.
+            raise OSError(os.errno.ENOENT, os.strerror(os.errno.ENOENT), 'cmake')
+        else:
+            # Different error
+            raise e
 
     if subprocess.call(["make", "-j4", "-C", "./build"]) != 0:
         raise EnvironmentError("error calling make build")


### PR DESCRIPTION
Before it throwed a complex exception just saying "file not found"  without explaining what was the cause. ( CMake wasn't found )., 

Now it tells the user that CMake can't be located.



The error message was:
```bash
Traceback (most recent call last):
  File "setup.py", line 67, in <module>
    setup_packages()
  File "setup.py", line 38, in setup_packages
    cmake_build()
  File "setup.py", line 22, in cmake_build
    if subprocess.call(["cmake", "-H./hfetch", "-B./hfetch/build"]) != 0:
  File "/gpfs/software/opt/python/2.7.14/lib/python2.7/subprocess.py", line 168, in call
    return Popen(*popenargs, **kwargs).wait()
  File "/gpfs/software/opt/python/2.7.14/lib/python2.7/subprocess.py", line 390, in __init__
    errread, errwrite)
  File "/gpfs/software/opt/python/2.7.14/lib/python2.7/subprocess.py", line 1025, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```



And now:

```bash
[polsm@bsc-100944 hecuba_git]$ python setup.py install --user
Traceback (most recent call last):
  File "setup.py", line 93, in <module>
    setup_packages()
  File "setup.py", line 61, in setup_packages
    cmake_build()
  File "setup.py", line 29, in cmake_build
    raise OSError(os.errno.ENOENT, os.strerror(os.errno.ENOENT), 'cmake')
OSError: [Errno 2] No such file or directory: 'cmake'
```