### PR TITLE
StorageDict.__contains__ return False

### DIFF
--- a/hecuba_py/src/hdict.py
+++ b/hecuba_py/src/hdict.py
@@ -321,7 +321,7 @@ class StorageDict(dict, IStorage):
                 return True
             except Exception as ex:
                 log.warn("persistentDict.__contains__ ex %s", ex)
-                raise ex
+                return False
 
     def _make_key(self, key):
         """


### PR DESCRIPTION
Now when the keys are not found it returns False instead of raising an exception.