### PR TITLE
storagedict now can make_persistent with an object already persistent

### DIFF
--- a/hecuba_py/src/hdict.py
+++ b/hecuba_py/src/hdict.py
@@ -565,10 +565,11 @@ class StorageDict(dict, IStorage):
 
         # Storing all in-memory values to cassandra
         for key, value in dict.iteritems(self):
-            if issubclass(value.__class__, IStorage) and not value._is_persistent:
+            if issubclass(value.__class__, IStorage):
                 # new name as ksp.table_valuename, where valuename is either defined by the user or set by hecuba
-                val_name = self._ksp + '.' + self._table + '_' + self._columns[0][0]
-                value.make_persistent(val_name)
+                if not value._is_persistent:
+                    val_name = self._ksp + '.' + self._table + '_' + self._columns[0][0]
+                    value.make_persistent(val_name)
                 value = value._storage_id
             self._hcache.put_row(self._make_key(key), self._make_value(value))
 

--- a/hecuba_py/src/hdict.py
+++ b/hecuba_py/src/hdict.py
@@ -565,7 +565,7 @@ class StorageDict(dict, IStorage):
 
         # Storing all in-memory values to cassandra
         for key, value in dict.iteritems(self):
-            if issubclass(value.__class__, IStorage):
+            if issubclass(value.__class__, IStorage) and not value._is_persistent:
                 # new name as ksp.table_valuename, where valuename is either defined by the user or set by hecuba
                 val_name = self._ksp + '.' + self._table + '_' + self._columns[0][0]
                 value.make_persistent(val_name)

--- a/hecuba_py/tests/withcassandra/storagedict_tests.py
+++ b/hecuba_py/tests/withcassandra/storagedict_tests.py
@@ -39,6 +39,19 @@ class MyStorageDictA(StorageDict):
     '''
 
 
+class mydict(StorageDict):
+    '''
+    @TypeSpec dict<<key0:int>, val0:tests.withcassandra.storagedict_tests.myobj2>
+    '''
+
+
+class myobj2(StorageObj):
+    '''
+    @ClassField attr1 int
+    @ClassField attr2 str
+    '''
+
+
 class StorageDictTest(unittest.TestCase):
     def test_init_empty(self):
         config.session.execute("DROP TABLE IF EXISTS my_app.tab1")
@@ -844,6 +857,18 @@ class StorageDictTest(unittest.TestCase):
         config.session.execute("DROP TABLE IF EXISTS my_app.first_name_mona_0")
         config.session.execute("DROP TABLE IF EXISTS my_app.first_name_mona_1")
         config.session.execute("DROP TABLE IF EXISTS my_app.second_name")
+
+    def test_make_persistent_with_persistent_obj(self):
+        o2 = myobj2("obj")
+        o2.attr1 = 1
+        o2.attr2 = "2"
+
+        d = mydict()
+        d[0] = o2
+        try:
+            d.make_persistent("dict")
+        except Exception as ex:
+            self.fail("Raised exception unexpectedly.\n" + str(ex))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When doing:
```python
o = mystorageobj("obj")
d = mydict()
d[0] = o2
d.make_persistent("dict")
```
o.make_persistent() was being called, but o was already persistent and that caused an exception.
Now it checks if the object is already persistent before calling make_persistent.
