### PR TITLE
Fixed getById with QbeastIterator

### DIFF
--- a/hecuba_py/src/__init__.py
+++ b/hecuba_py/src/__init__.py
@@ -222,8 +222,8 @@ class Config:
                         "CREATE KEYSPACE IF NOT EXISTS hecuba  WITH replication = %s" % singleton.replication,
                         """CREATE TYPE IF NOT EXISTS hecuba.q_meta(
                         mem_filter text, 
-                        from_point frozen<list<float>>,
-                        to_point frozen<list<float>>,
+                        from_point frozen<list<double>>,
+                        to_point frozen<list<double>>,
                         precision float);
                         """,
                         'CREATE TYPE IF NOT EXISTS hecuba.np_meta(dims frozen<list<int>>,type int,block_id int);',

--- a/hecuba_py/src/qbeast.py
+++ b/hecuba_py/src/qbeast.py
@@ -18,11 +18,7 @@ class QbeastMeta(object):
         self.mem_filter = mem_filter
 
 
-config.session.execute("CREATE TYPE IF NOT EXISTS hecuba.q_meta("
-                       "precision float,"
-                       "from_point frozen<list<double>>,"
-                       "to_point frozen<list<double>>,"
-                       "mem_filter text)")
+config.cluster.register_user_type('hecuba', 'q_meta', QbeastMeta)
 
 
 class QbeastIterator(IStorage):

--- a/hecuba_py/src/qbeast.py
+++ b/hecuba_py/src/qbeast.py
@@ -13,12 +13,16 @@ from IStorage import IStorage
 class QbeastMeta(object):
     def __init__(self, mem_filter, from_point, to_point, precision):
         self.precision = precision
-        self.to_point = to_point
         self.from_point = from_point
+        self.to_point = to_point
         self.mem_filter = mem_filter
 
 
-config.cluster.register_user_type('hecuba', 'q_meta', QbeastMeta)
+config.session.execute("CREATE TYPE IF NOT EXISTS hecuba.q_meta("
+                       "precision float,"
+                       "from_point frozen<list<double>>,"
+                       "to_point frozen<list<double>>,"
+                       "mem_filter text)")
 
 
 class QbeastIterator(IStorage):
@@ -27,12 +31,12 @@ class QbeastIterator(IStorage):
     """
     args_names = ['primary_keys', 'columns', 'indexed_on', 'name', 'qbeast_meta', 'qbeast_random',
                   'storage_id', 'tokens', 'class_name']
-    _building_args = namedtuple('StorageDictArgs', args_names)
+    _building_args = namedtuple('QbeastArgs', args_names)
     _prepared_store_meta = config.session.prepare(
         'INSERT INTO hecuba.istorage'
-        '(primary_keys, columns, name, qbeast_meta,'
+        '(primary_keys, columns, indexed_on, name, qbeast_meta,'
         ' qbeast_random, storage_id, tokens, class_name)'
-        'VALUES (?,?,?,?,?,?,?,?)')
+        'VALUES (?,?,?,?,?,?,?,?,?)')
     _prepared_set_qbeast_meta = config.session.prepare(
         'INSERT INTO hecuba.istorage (storage_id, qbeast_meta)VALUES (?,?)')
     _row_namedtuple = namedtuple("row", "key,value")
@@ -45,6 +49,7 @@ class QbeastIterator(IStorage):
             config.session.execute(QbeastIterator._prepared_store_meta,
                                    [storage_args.primary_keys,
                                     storage_args.columns,
+                                    storage_args.indexed_on,
                                     storage_args.name,
                                     storage_args.qbeast_meta,
                                     storage_args.qbeast_random,
@@ -100,13 +105,15 @@ class QbeastIterator(IStorage):
 
         if storage_id is None:
             self._storage_id = uuid.uuid4()
-            save = True
         else:
             self._storage_id = storage_id
-            save = False
+
+        build_keys = [(key["name"], key["type"]) if isinstance(key, dict) else key for key in primary_keys]
+        build_columns = [(col["name"], col["type"]) if isinstance(col, dict) else col for col in columns]
+
         self._build_args = self._building_args(
-            primary_keys,
-            columns,
+            build_keys,
+            build_columns,
             self._indexed_on,
             self._ksp + "." + self._table,
             self._qbeast_meta,
@@ -114,10 +121,11 @@ class QbeastIterator(IStorage):
             self._storage_id,
             self._tokens,
             class_name)
-        if save:
-            self._store_meta(self._build_args)
 
-        persistent_columns = [{"name": col[0], "type": col[1]} for col in columns]
+        self._store_meta(self._build_args)
+
+        persistent_columns = [{"name": col[0], "type": col[1]} if isinstance(col, tuple) else col for col in columns]
+
         self._hcache_params = (self._ksp, self._table,
                                self._storage_id,
                                self._tokens, key_names, persistent_columns,

--- a/hecuba_py/tests/withQbeast/qbeast_storagedict_tests.py
+++ b/hecuba_py/tests/withQbeast/qbeast_storagedict_tests.py
@@ -68,10 +68,11 @@ class QbeastStorageDictTest(unittest.TestCase):
             d[i, i + 1.0] = [i * 0.1 / 9.0, i * 0.2 / 9.0, i * 0.3 / 9.0]
 
         time.sleep(1)
-
+        filtered = filter(lambda row: row.x > 0.02 and row.x < 0.25 and row.y > 0.26 and row.y < 0.45 and row.z > 0.58 and row.z < 0.9, d.iteritems())
         from storage.api import getByID
-        it2 = getByID(d.getID())
-        self.assertEqual(d.getID(), it2.getID())
+        for partition in filtered.split():
+            it2 = getByID(partition.getID())
+            self.assertEqual(filtered._qbeast_random, it2._qbeast_random)
 
     def testBuildRemotely(self):
         config.session.execute("DROP TABLE IF EXISTS my_app.indexed_dict")


### PR DESCRIPTION
Objects created by a split were storing the metadata in hecuba.istorage badly.