### PR TITLE
Increment ref count for Py_None when reading from cassandra

### DIFF
--- a/hecuba_core/src/py_interface/PythonParser.cpp
+++ b/hecuba_core/src/py_interface/PythonParser.cpp
@@ -86,7 +86,10 @@ PyObject *PythonParser::make_pylist(std::vector<const TupleRow *> &values) const
     PyObject *list = PyList_New(tuple->n_elem());
     for (uint16_t i = 0; i < tuple->n_elem(); i++) {
         if (!tuple->isNull(i)) PyList_SetItem(list, i, this->parsers[i]->c_to_py(tuple->get_element(i)));
-        else PyList_SetItem(list, i, Py_None);
+        else {
+            Py_INCREF(Py_None);
+            PyList_SetItem(list, i, Py_None);
+        }
     }
     return list;
 }


### PR DESCRIPTION
Py_None is a static object and every structure holding a reference to it should increment the Py-None refcount.

We forgot to increment the reference when building a Py_None after reading a Null on Cassandra. 