### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 cassandra-driver >= 3.7.1
-regex
 ##testing
 nose>=1.3.7
 mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-thrift==0.9.2
-byteplay
 cassandra-driver >= 3.7.1
 regex
 ##testing


### PR DESCRIPTION
Hecuba no longer uses thrift nor byteplay, so they should be removed from requirements.txt