### PR TITLE
Token split must be an integer

### DIFF
--- a/hecuba_py/hecuba/tools.py
+++ b/hecuba_py/hecuba/tools.py
@@ -111,7 +111,7 @@ def tokens_partitions(ksp, table, tokens_ranges):
             (mean_p_size, p_count) = one
             estimated_size = mean_p_size * p_count
             if estimated_size > 0:
-                step_size = _max_token // (
+                step_size = _max_token // int(
                     max(estimated_size / target_token_range_size,
                         splits_per_node * n_nodes)
                 )


### PR DESCRIPTION
The partitioner generated tokens of type float. 