### PR TITLE
Array metadatas hold all available information

### DIFF
--- a/hecuba_core/src/ArrayDataStore.cpp
+++ b/hecuba_core/src/ArrayDataStore.cpp
@@ -31,69 +31,6 @@ ArrayDataStore::~ArrayDataStore() {
 
 
 /***
- * Stores the array metadata by setting the cluster and block ids to -1. Deletes the array metadata afterwards.
- * @param storage_id UUID used as part of the key
- * @param np_metas ArrayMetadata
- */
-
-void ArrayDataStore::update_metadata(const uint64_t *storage_id, ArrayMetadata *metadata) const {
-    uint32_t offset = 0, keys_size = sizeof(uint64_t *) + sizeof(int32_t) * 2;
-
-    int32_t cluster_id = -1, block_id = -1;
-
-    char *keys = (char *) malloc(keys_size);
-    //UUID
-    uint64_t *c_uuid = (uint64_t *) malloc(sizeof(uint64_t) * 2);//new uint64_t[2];
-    c_uuid[0] = *storage_id;
-    c_uuid[1] = *(storage_id + 1);
-    // [0] = storage_id.time_and_version;
-    // [1] = storage_id.clock_seq_and_node;
-    memcpy(keys, &c_uuid, sizeof(uint64_t *));
-    offset = sizeof(uint64_t *);
-    //Cluster id
-    memcpy(keys + offset, &cluster_id, sizeof(int32_t));
-    offset += sizeof(int32_t);
-    //Block id
-    memcpy(keys + offset, &block_id, sizeof(int32_t));
-
-
-
-
-    //COPY VALUES
-    offset = 0;
-    void *values = (char *) malloc(sizeof(char *));
-
-    //size of the vector of dims
-    uint64_t size = sizeof(uint32_t) * metadata->dims.size();
-
-    //plus the other metas
-    size += sizeof(metadata->elem_size) + sizeof(metadata->inner_type) + sizeof(metadata->partition_type);
-
-    //allocate plus the bytes counter
-    unsigned char *byte_array = (unsigned char *) malloc(size + sizeof(uint64_t));
-
-    // Copy num bytes
-    memcpy(byte_array, &size, sizeof(uint64_t));
-    offset += sizeof(uint64_t);
-
-    //copy everything from the metas
-    memcpy(byte_array + offset, &metadata->elem_size, sizeof(metadata->elem_size));
-    offset += sizeof(metadata->elem_size);
-    memcpy(byte_array + offset, &metadata->inner_type, sizeof(metadata->inner_type));
-    offset += sizeof(metadata->inner_type);
-    memcpy(byte_array + offset, &metadata->partition_type, sizeof(metadata->partition_type));
-    offset += sizeof(metadata->partition_type);
-    memcpy(byte_array + offset, metadata->dims.data(), sizeof(uint32_t) * metadata->dims.size());
-
-
-    // Copy ptr to bytearray
-    memcpy(values, &byte_array, sizeof(unsigned char *));
-
-    // Finally, we write the data
-    cache->put_crow(keys, values);
-}
-
-/***
  * Write a complete numpy ndarray by using the partitioning mechanism defined in the metadata
  * @param storage_id identifying the numpy ndarray
  * @param np_metas ndarray characteristics
@@ -138,65 +75,6 @@ void ArrayDataStore::store(const uint64_t *storage_id, ArrayMetadata *metadata, 
     delete (partitions_it);
 
     // No need to flush the elements because the metadata are written after the data thanks to the queue
-}
-
-
-/***
- * Reads the metadata from the storage as an ArrayMetadata for latter use
- * @param storage_id identifing the numpy ndarray
- * @param cache
- * @return
- */
-ArrayMetadata *ArrayDataStore::read_metadata(const uint64_t *storage_id) const {
-    // Get metas from Cassandra
-    int32_t cluster_id = -1, block_id = -1;
-
-    char *buffer = (char *) malloc(sizeof(uint64_t *) + sizeof(int32_t) * 2);
-    // UUID
-    uint64_t *c_uuid = (uint64_t *) malloc(sizeof(uint64_t) * 2);
-    c_uuid[0] = *storage_id;
-    c_uuid[1] = *(storage_id + 1);
-    // Copy uuid
-    memcpy(buffer, &c_uuid, sizeof(uint64_t *));
-    int32_t offset = sizeof(uint64_t *);
-    // Cluster id
-    memcpy(buffer + offset, &cluster_id, sizeof(int32_t));
-    offset += sizeof(int32_t);
-    // Cluster id
-    memcpy(buffer + offset, &block_id, sizeof(int32_t));
-
-
-    // We fetch the data
-    std::vector<const TupleRow *> results = cache->get_crow(buffer);
-
-    if (results.empty()) throw ModuleException("Metadata for the array can't be found");
-
-    // pos 0 is block id, pos 1 is payload
-    const unsigned char *payload = *((const unsigned char **) (results[0]->get_element(0)));
-
-    const uint64_t num_bytes = *((uint64_t *) payload);
-    // Move pointer to the beginning of the data
-    payload = payload + sizeof(num_bytes);
-
-
-    uint32_t bytes_offset = 0;
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    // Load data
-    memcpy(&arr_metas->elem_size, payload, sizeof(arr_metas->elem_size));
-    bytes_offset += sizeof(arr_metas->elem_size);
-    memcpy(&arr_metas->inner_type, payload + bytes_offset, sizeof(arr_metas->inner_type));
-    bytes_offset += sizeof(arr_metas->inner_type);
-    memcpy(&arr_metas->partition_type, payload + bytes_offset, sizeof(arr_metas->partition_type));
-    bytes_offset += sizeof(arr_metas->partition_type);
-
-    uint64_t nbytes = num_bytes - bytes_offset;
-    uint32_t nelem = (uint32_t) nbytes / sizeof(uint32_t);
-    if (nbytes % sizeof(uint32_t) != 0) throw ModuleException("something went wrong reading the dims of a numpy");
-    arr_metas->dims = std::vector<uint32_t>(nelem);
-    memcpy(arr_metas->dims.data(), payload + bytes_offset, nbytes);
-
-    for (const TupleRow *&v : results) delete (v);
-    return arr_metas;
 }
 
 

--- a/hecuba_core/src/SpaceFillingCurve.h
+++ b/hecuba_core/src/SpaceFillingCurve.h
@@ -31,19 +31,22 @@ struct Partition {
 //TODO Inherit from CassUserType, pass the user type directly
 //Represents the shape and type of an array
 struct ArrayMetadata {
-    ArrayMetadata() {}
+    ArrayMetadata() = default;
 
-    ArrayMetadata(std::vector<uint32_t> dims, int32_t inner_type, uint32_t elem_size, uint8_t partition_type) {
+    ArrayMetadata(std::vector<uint32_t> &dims, std::vector<uint32_t> &strides, uint32_t elem_size,
+                  uint8_t partition_type, std::string &typekind, std::string &byteorder) {
         this->dims = dims;
-        this->inner_type = inner_type;
+        this->strides = strides;
         this->elem_size = elem_size;
         this->partition_type = partition_type;
+        this->typekind = typekind;
+        this->byteorder = byteorder;
     }
 
-    std::vector<uint32_t> dims;
-    int32_t inner_type;
-    uint32_t elem_size;
+    std::vector<uint32_t> dims, strides;
+    uint32_t elem_size, flags;
     uint8_t partition_type;
+    std::string typekind, byteorder;
 };
 
 

--- a/hecuba_core/src/py_interface/NumpyStorage.cpp
+++ b/hecuba_core/src/py_interface/NumpyStorage.cpp
@@ -14,91 +14,140 @@ NumpyStorage::~NumpyStorage() {
 };
 
 
-void NumpyStorage::store_numpy(const uint64_t *storage_id, PyArrayObject *numpy) const {
-
-    ArrayMetadata *np_metas = this->get_np_metadata(numpy);
-    np_metas->partition_type = ZORDER_ALGORITHM;
-
+void NumpyStorage::store_numpy(const uint64_t *storage_id, PyArrayObject *numpy, ArrayMetadata *np_metas) const {
     void *data = PyArray_BYTES(numpy);
     this->store(storage_id, np_metas, data);
-    this->update_metadata(storage_id, np_metas);
-    delete (np_metas);
 }
 
 
 /***
  * Reads a numpy ndarray by fetching the clusters independently
  * @param storage_id of the array to retrieve
+ * @param np_metas array description
  * @return Numpy ndarray as a Python object
  */
-PyObject *NumpyStorage::read_numpy(const uint64_t *storage_id) {
-    ArrayMetadata *np_metas = this->read_metadata(storage_id);
+PyObject *NumpyStorage::read_numpy(const uint64_t *storage_id, ArrayMetadata *np_metas) {
     void *data = this->read(storage_id, np_metas);
-
 
     npy_intp *dims = new npy_intp[np_metas->dims.size()];
     for (uint32_t i = 0; i < np_metas->dims.size(); ++i) {
         dims[i] = np_metas->dims[i];
     }
 
+    int32_t type = PyArray_TypestrConvert(np_metas->elem_size, np_metas->typekind[0]);
+    if (type == NPY_NOTYPE)
+        throw ModuleException("Can't identify Numpy dtype from typekind");
+
     PyObject *resulting_array;
     try {
-        resulting_array = PyArray_SimpleNewFromData((int32_t) np_metas->dims.size(), dims, np_metas->inner_type, data);
+        resulting_array = PyArray_SimpleNewFromData((int32_t) np_metas->dims.size(), dims, type, data);
 
         PyArrayObject *converted_array;
         PyArray_OutputConverter(resulting_array, &converted_array);
         PyArray_ENABLEFLAGS(converted_array, NPY_ARRAY_OWNDATA);
     }
-    catch (std::exception e) {
+    catch (std::exception &e) {
         if (PyErr_Occurred()) PyErr_Print();
         PyErr_SetString(PyExc_RuntimeError, e.what());
         return NULL;
     }
-
-    delete (np_metas);
-
     return resulting_array;
 }
 
-/***
- * Extract the metadatas of the given numpy ndarray and return a new ArrayMetadata with its representation
- * @param numpy Ndarray to extract the metadata
- * @return ArrayMetadata defining the information to reconstruct a numpy ndarray
- */
-ArrayMetadata *NumpyStorage::get_np_metadata(PyArrayObject *numpy) const {
-    int64_t ndims = PyArray_NDIM(numpy);
-    npy_intp *shape = PyArray_SHAPE(numpy);
 
-    ArrayMetadata *shape_and_type = new ArrayMetadata();
-    shape_and_type->inner_type = PyArray_TYPE(numpy);
+ArrayMetadata *NumpyStorage::make_metadata(PyObject *py_np_metas) const {
 
-    //TODO implement as a union
-    if (shape_and_type->inner_type == NPY_INT8) shape_and_type->elem_size = sizeof(int8_t);
-    else if (shape_and_type->inner_type == NPY_UINT8) shape_and_type->elem_size = sizeof(uint8_t);
-    else if (shape_and_type->inner_type == NPY_INT16) shape_and_type->elem_size = sizeof(int16_t);
-    else if (shape_and_type->inner_type == NPY_UINT16) shape_and_type->elem_size = sizeof(uint16_t);
-    else if (shape_and_type->inner_type == NPY_INT32) shape_and_type->elem_size = sizeof(int32_t);
-    else if (shape_and_type->inner_type == NPY_UINT32) shape_and_type->elem_size = sizeof(uint32_t);
-    else if (shape_and_type->inner_type == NPY_INT64) shape_and_type->elem_size = sizeof(int64_t);
-    else if (shape_and_type->inner_type == NPY_LONGLONG) shape_and_type->elem_size = sizeof(int64_t);
-    else if (shape_and_type->inner_type == NPY_UINT64) shape_and_type->elem_size = sizeof(uint64_t);
-    else if (shape_and_type->inner_type == NPY_ULONGLONG) shape_and_type->elem_size = sizeof(uint64_t);
-    else if (shape_and_type->inner_type == NPY_DOUBLE) shape_and_type->elem_size = sizeof(npy_double);
-    else if (shape_and_type->inner_type == NPY_FLOAT16) shape_and_type->elem_size = sizeof(npy_float16);
-    else if (shape_and_type->inner_type == NPY_FLOAT32) shape_and_type->elem_size = sizeof(npy_float32);
-    else if (shape_and_type->inner_type == NPY_FLOAT64) shape_and_type->elem_size = sizeof(npy_float64);
-    else if (shape_and_type->inner_type == NPY_FLOAT128) shape_and_type->elem_size = sizeof(npy_float128);
-    else if (shape_and_type->inner_type == NPY_BOOL) shape_and_type->elem_size = sizeof(bool);
-    else if (shape_and_type->inner_type == NPY_BYTE) shape_and_type->elem_size = sizeof(char);
-    else if (shape_and_type->inner_type == NPY_LONG) shape_and_type->elem_size = sizeof(long);
-    else if (shape_and_type->inner_type == NPY_LONGLONG) shape_and_type->elem_size = sizeof(long long);
-    else if (shape_and_type->inner_type == NPY_SHORT) shape_and_type->elem_size = sizeof(short);
-    else throw ModuleException("Numpy data type still not supported");
-
-    // Copy elements per dimension
-    shape_and_type->dims = std::vector<uint32_t>((uint64_t) ndims);//PyArray_SHAPE()
-    for (int32_t dim = 0; dim < ndims; ++dim) {
-        shape_and_type->dims[dim] = (uint32_t) shape[dim];
+    const char *expected = "np_meta"; //hecuba.hnumpy.StorageNumpy.
+    if (strlen(py_np_metas->ob_type->tp_name) != strlen(expected) ||
+        memcmp(py_np_metas->ob_type->tp_name, expected, strlen(expected)) != 0) {
+        PyErr_SetString(PyExc_ValueError, "Numpy metadata class does not match the expected");
+        std::cerr << py_np_metas->ob_type->tp_name << std::endl;
+        return NULL;
     }
-    return shape_and_type;
+
+    ArrayMetadata *np_meta = new ArrayMetadata();
+
+    // elem_size (itemsize)
+    PyObject *attr = PyObject_GetAttrString(py_np_metas, "elem_size");
+    if (attr == Py_None) return nullptr;
+    if (!PyLong_Check(attr) || !PyArg_Parse(attr, Py_INT, &np_meta->elem_size))
+        throw ModuleException("Numpy elem_size must be an int");
+    Py_DECREF(attr);
+
+
+
+    // Dims and ndims
+    attr = PyObject_GetAttrString(py_np_metas, "dims");
+    if (attr == Py_None || !PyList_Check(attr)) return nullptr;
+    int32_t ndims = PyList_Size(attr);
+    np_meta->dims.resize(ndims);
+    np_meta->strides.resize(ndims);
+
+
+    for (uint32_t dim_i = 0; dim_i < ndims; ++dim_i) {
+        PyObject *elem_dim = PyList_GetItem(attr, dim_i);
+        if (elem_dim == Py_None) return nullptr;
+        if (!PyLong_Check(elem_dim) || !PyArg_Parse(elem_dim, Py_INT, &np_meta->dims[dim_i]))
+            throw ModuleException("Numpy dims must be a list of ints");
+    }
+    Py_DECREF(attr);
+
+
+    // Strides
+    attr = PyObject_GetAttrString(py_np_metas, "strides");
+    if (attr == Py_None || !PyList_Check(attr)) return nullptr;
+    else {
+        if (PyList_Size(attr) != ndims) throw ModuleException("Numpy strides must be a list of ints");
+        for (uint32_t dim_i = 0; dim_i < ndims; ++dim_i) {
+            PyObject *elem_dim = PyList_GetItem(attr, dim_i);
+            if (elem_dim == Py_None) return nullptr;
+            if (!PyLong_Check(elem_dim) || !PyArg_Parse(elem_dim, Py_INT, &np_meta->strides[dim_i]))
+                throw ModuleException("Numpy strides must be a list of ints");
+        }
+    }
+    Py_DECREF(attr);
+
+
+    // Typekind (gentype) != typecode
+    attr = PyObject_GetAttrString(py_np_metas, "typekind");
+    if (attr == Py_None) return nullptr;
+
+    if (PyUnicode_Check(attr)) {
+        Py_ssize_t l_size;
+        const char *l_temp = PyUnicode_AsUTF8AndSize(attr, &l_size);
+        if (!l_temp)
+            throw ModuleException("Numpy typekind must be UTF8");
+        np_meta->typekind = std::string(l_temp, l_size + 1);
+    }
+    Py_DECREF(attr);
+
+    // Byteorder
+    attr = PyObject_GetAttrString(py_np_metas, "byteorder");
+    if (attr == Py_None) return nullptr;
+
+    if (PyUnicode_Check(attr)) {
+        Py_ssize_t l_size;
+        const char *l_temp = PyUnicode_AsUTF8AndSize(attr, &l_size);
+        if (!l_temp)
+            throw ModuleException("Byteorder must be UTF8");
+        np_meta->byteorder = std::string(l_temp, l_size + 1);
+    }
+    Py_DECREF(attr);
+
+
+    // Flags
+    attr = PyObject_GetAttrString(py_np_metas, "flags");
+    if (attr == Py_None) np_meta->flags = 0;
+    else if (!PyLong_Check(attr) || !PyArg_Parse(attr, Py_INT, &np_meta->flags))
+        throw ModuleException("Numpy flgs must be an int");
+    Py_DECREF(attr);
+
+    // Partition algorithm
+    attr = PyObject_GetAttrString(py_np_metas, "partition_type");
+    if (attr == Py_None) np_meta->partition_type = NO_PARTITIONS;
+    else if (!PyLong_Check(attr) || !PyArg_Parse(attr, Py_SHORT_INT, &np_meta->partition_type))
+        throw ModuleException("Numpy partition type must be an int");
+    Py_DECREF(attr);
+
+    return np_meta;
 }

--- a/hecuba_core/src/py_interface/NumpyStorage.h
+++ b/hecuba_core/src/py_interface/NumpyStorage.h
@@ -11,6 +11,7 @@
 #define PY_ARRAY_UNIQUE_SYMBOL cool_ARRAY_API
 
 #include "numpy/arrayobject.h"
+#include "UnitParser.h"
 
 /***
  * Responsible to store a numpy to the keyspace.table_numpies, associating an attribute_name and a storage_id(uuid)
@@ -25,15 +26,11 @@ public:
 
     ~NumpyStorage();
 
-    void store_numpy(const uint64_t *storage_id, PyArrayObject *numpy) const;
+    void store_numpy(const uint64_t *storage_id, PyArrayObject *numpy, ArrayMetadata *) const;
 
-    PyObject *read_numpy(const uint64_t *storage_id);
+    PyObject *read_numpy(const uint64_t *storage_id, ArrayMetadata *np_metas);
 
-
-private:
-
-    ArrayMetadata *get_np_metadata(PyArrayObject *numpy) const;
-
+    ArrayMetadata *make_metadata(PyObject *py_np_metas) const;
 };
 
 

--- a/hecuba_core/tests/runtests.cpp
+++ b/hecuba_core/tests/runtests.cpp
@@ -250,7 +250,6 @@ TEST(TestMakePartitions, 2DZorder) {
     std::vector<uint32_t> ccs = {nrows, ncols};
     ArrayMetadata *arr_metas = new ArrayMetadata();
     arr_metas->dims = ccs;
-    arr_metas->inner_type = CASS_VALUE_TYPE_INT;
     arr_metas->elem_size = sizeof(int32_t);
     arr_metas->partition_type = ZORDER_ALGORITHM;
 
@@ -304,7 +303,6 @@ TEST(TestMakePartitions, 2DZorderZeroes) {
     std::vector<uint32_t> ccs = {nrows, ncols};
     ArrayMetadata *arr_metas = new ArrayMetadata();
     arr_metas->dims = ccs;
-    arr_metas->inner_type = CASS_VALUE_TYPE_DOUBLE;
     arr_metas->elem_size = sizeof(double);
     arr_metas->partition_type = ZORDER_ALGORITHM;
 
@@ -351,7 +349,6 @@ TEST(TestMakePartitions, 3DZorder_Small) {
     std::vector<uint32_t> ccs = {17, 17, 17};
     ArrayMetadata *arr_metas = new ArrayMetadata();
     arr_metas->dims = ccs;
-    arr_metas->inner_type = CASS_VALUE_TYPE_INT;
     arr_metas->elem_size = sizeof(int32_t);
     arr_metas->partition_type = ZORDER_ALGORITHM;
 
@@ -406,7 +403,6 @@ TEST(TestMakePartitions, 3DZorder_Medium) {
     std::vector<uint32_t> ccs = {250, 150, 500};
     ArrayMetadata *arr_metas = new ArrayMetadata();
     arr_metas->dims = ccs;
-    arr_metas->inner_type = CASS_VALUE_TYPE_INT;
     arr_metas->elem_size = sizeof(int32_t);
     arr_metas->partition_type = ZORDER_ALGORITHM;
 
@@ -462,7 +458,6 @@ TEST(TestMakePartitions, 3DZorder_Big) {
     std::vector<uint32_t> ccs = {512, 256, 512};
     ArrayMetadata *arr_metas = new ArrayMetadata();
     arr_metas->dims = ccs;
-    arr_metas->inner_type = CASS_VALUE_TYPE_INT;
     arr_metas->elem_size = sizeof(int32_t);
     arr_metas->partition_type = ZORDER_ALGORITHM;
 
@@ -521,7 +516,6 @@ TEST(TestMakePartitions, NDZorder) {
     ArrayMetadata *arr_metas = new ArrayMetadata();
     while (ccs.size() <= max_dims) {
         arr_metas->dims = ccs;
-        arr_metas->inner_type = CASS_VALUE_TYPE_INT;
         arr_metas->elem_size = sizeof(int32_t);
         arr_metas->partition_type = ZORDER_ALGORITHM;
 
@@ -584,7 +578,6 @@ TEST(TestMakePartitions, 2DZorder128Double) {
     std::vector<uint32_t> ccs = {nrows, ncols}; //4D 128 elements
     ArrayMetadata *arr_metas = new ArrayMetadata();
     arr_metas->dims = ccs;
-    arr_metas->inner_type = CASS_VALUE_TYPE_DOUBLE;
     arr_metas->elem_size = sizeof(double);
     arr_metas->partition_type = ZORDER_ALGORITHM;
 
@@ -643,7 +636,6 @@ TEST(TestMakePartitions, 2DZorderByRange) {
             std::vector<uint32_t> ccs = {nrows, ncols}; //4D 128 elements
             ArrayMetadata *arr_metas = new ArrayMetadata();
             arr_metas->dims = ccs;
-            arr_metas->inner_type = CASS_VALUE_TYPE_DOUBLE;
             arr_metas->elem_size = sizeof(double);
             arr_metas->partition_type = ZORDER_ALGORITHM;
 
@@ -708,7 +700,6 @@ TEST(TestMakePartitions, 2DNopart) {
     std::vector<uint32_t> ccs = {ncols, nrows};
     ArrayMetadata *arr_metas = new ArrayMetadata();
     arr_metas->dims = ccs;
-    arr_metas->inner_type = CASS_VALUE_TYPE_INT;
     arr_metas->elem_size = sizeof(int32_t);
     arr_metas->partition_type = NO_PARTITIONS;
 
@@ -742,7 +733,6 @@ TEST(TestMakePartitions, 3DZorderAndReverse) {
     std::vector<uint32_t> ccs = {45, 17, 32};
     ArrayMetadata *arr_metas = new ArrayMetadata();
     arr_metas->dims = ccs;
-    arr_metas->inner_type = CASS_VALUE_TYPE_INT;
     arr_metas->elem_size = sizeof(int32_t);
     arr_metas->partition_type = ZORDER_ALGORITHM;
 
@@ -814,7 +804,6 @@ TEST(TestMakePartitions, 4DZorderAndReverse) {
     std::vector<uint32_t> ccs = {100, 20, 150, 30};
     ArrayMetadata *arr_metas = new ArrayMetadata();
     arr_metas->dims = ccs;
-    arr_metas->inner_type = CASS_VALUE_TYPE_INT;
     arr_metas->elem_size = sizeof(int32_t);
     arr_metas->partition_type = ZORDER_ALGORITHM;
 
@@ -883,7 +872,6 @@ TEST(TestMakePartitions, ReadBlockOnlyOnce) {
     std::vector<uint32_t> ccs = {nrows, ncols};
     ArrayMetadata *arr_metas = new ArrayMetadata();
     arr_metas->dims = ccs;
-    arr_metas->inner_type = CASS_VALUE_TYPE_INT;
     arr_metas->elem_size = sizeof(int32_t);
     arr_metas->partition_type = ZORDER_ALGORITHM;
 

--- a/hecuba_py/hecuba/__init__.py
+++ b/hecuba_py/hecuba/__init__.py
@@ -212,7 +212,8 @@ class Config:
                 to_point frozen<list<double>>,
                 precision float);
                 """,
-                'CREATE TYPE IF NOT EXISTS hecuba.np_meta(dims frozen<list<int>>,type int,block_id int);',
+                """CREATE TYPE IF NOT EXISTS hecuba.np_meta (flags int, elem_size int, partition_type int,
+                dims list<int>, strides list<int>, typekind text, byteorder text)""",
                 """CREATE TABLE IF NOT EXISTS hecuba
                 .istorage (storage_id uuid, 
                 class_name text,name text, 

--- a/hecuba_py/hecuba/hnumpy.py
+++ b/hecuba_py/hecuba/hnumpy.py
@@ -8,49 +8,48 @@ from .IStorage import IStorage
 from .tools import extract_ks_tab, get_istorage_attrs
 
 
-class StorageNumpy(IStorage, np.ndarray):
-    class np_meta(object):
-        def __init__(self, shape, dtype, block_id):
-            self.dims = shape
-            self.type = dtype
-            self.block_id = block_id
+class np_meta:
 
+    def __init__(self, flags, elem_size, partition_type, dims, strides, kind, byteorder):
+        self.flags = flags
+        self.elem_size = elem_size
+        self.partition_type = partition_type
+        self.dims = list(dims)
+        self.strides = list(strides)
+        self.typekind = kind
+        self.byteorder = byteorder
+
+    def __repr__(self):
+        return f"""{self.flags, self.elem_size, self.partition_type,
+                    self.dims, self.strides, self.typekind, self.byteorder}"""
+
+
+class StorageNumpy(IStorage, np.ndarray):
     _build_args = None
     _prepared_store_meta = config.session.prepare('INSERT INTO hecuba.istorage'
                                                   '(storage_id, class_name, name, numpy_meta)'
                                                   'VALUES (?,?,?,?)')
 
-    args_names = ["storage_id", "class_name", "name", "shape", "dtype", "block_id", "built_remotely"]
+    args_names = ["storage_id", "class_name", "name", "metas"]
     args = namedtuple('StorageNumpyArgs', args_names)
 
-    def __new__(cls, input_array=None, storage_id=None, name=None, built_remotely=False, **kwargs):
-        if name:
-            name = name + '_numpies'
-        elif storage_id:
-            metas = get_istorage_attrs(storage_id)
-            name = metas[0].name
-        if input_array is None and name and storage_id is not None:
-            result = cls.load_array(storage_id, name)
+    def __new__(cls, input_array=None, storage_id=None, name=None, **kwargs):
+        if input_array is None and storage_id is not None:
+            # Load metadata
+            istorage_metas = get_istorage_attrs(storage_id)
+            name = name or istorage_metas[0].name
+            numpy_metadata = istorage_metas[0].numpy_meta
+
+            # Load array
+            result = cls.load_array(storage_id, name, numpy_metadata)
             input_array = result[0]
             obj = np.asarray(input_array).view(cls)
             (obj._ksp, obj._table) = extract_ks_tab(name)
             obj._hcache = result[1]
-            # obj.storage_id = storage_id
-            # obj._is_persistent = True
-        elif not name and storage_id is not None:
-            raise RuntimeError("hnumpy received storage id but not a name")
-        elif (input_array is not None and name and storage_id is not None) \
-                or (storage_id is None and name):
-            obj = np.asarray(input_array).view(cls)
-            obj.storage_id = storage_id
-            obj._is_persistent = False
         else:
             obj = np.asarray(input_array).view(cls)
-            obj.storage_id = storage_id
-            obj._is_persistent = storage_id is not None
+
         # Finally, we must return the newly created object:
-        obj._block_id = -1
-        obj._built_remotely = built_remotely
         obj._class_name = '%s.%s' % (cls.__module__, cls.__name__)
         return obj
 
@@ -58,6 +57,11 @@ class StorageNumpy(IStorage, np.ndarray):
         IStorage.__init__(self, storage_id=storage_id, name=name, **kwargs)
         if input_array is not None and (name or storage_id):
             self.make_persistent(name)
+
+        metas = np_meta(self.flags.num, self.itemsize, 0, self.shape, self.strides, self.dtype.kind,
+                        self.dtype.byteorder)
+
+        self._build_args = self.args(self.storage_id, self._class_name, self._get_name(), metas)
 
     # used as copy constructor
     def __array_finalize__(self, obj):
@@ -78,7 +82,7 @@ class StorageNumpy(IStorage, np.ndarray):
                                                                 'PRIMARY KEY((storage_id,cluster_id),block_id))')
 
     @staticmethod
-    def _create_hcache(storage_id, name):
+    def _create_hcache(name):
         (ksp, table) = extract_ks_tab(name)
         hcache_params = (ksp, table,
                          {'cache_size': config.max_cache_size,
@@ -99,39 +103,34 @@ class StorageNumpy(IStorage, np.ndarray):
         try:
             config.session.execute(StorageNumpy._prepared_store_meta,
                                    [storage_args.storage_id, storage_args.class_name,
-                                    storage_args.name, StorageNumpy.np_meta(storage_args.shape, storage_args.dtype,
-                                                                            storage_args.block_id)])
+                                    storage_args.name, storage_args.metas])
 
         except Exception as ex:
             log.warn("Error creating the StorageNumpy metadata with args: %s" % str(storage_args))
             raise ex
 
     @staticmethod
-    def load_array(storage_id, name):
-        hcache = StorageNumpy._create_hcache(storage_id, name)
-        result = hcache.get_numpy([storage_id])
-        if len(result) == 1:
-            return [result[0], hcache]
-        else:
-            raise KeyError
+    def load_array(storage_id, name, metas):
+        hcache = StorageNumpy._create_hcache(name)
+        result = hcache.get_numpy(storage_id, metas)
+        return [result, hcache]
 
     def make_persistent(self, name):
-        if not name.endswith("_numpies"):
-            name = name + '_numpies'
-
         super().make_persistent(name)
-
-        self._build_args = self.args(self.storage_id, self._class_name, self._ksp + '.' + self._table,
-                                     self.shape, self.dtype.num, self._block_id, self._built_remotely)
 
         if not self._built_remotely:
             self._create_tables(name)
 
         if not getattr(self, '_hcache', None):
-            self._hcache = self._create_hcache(self.storage_id, name)
+            self._hcache = self._create_hcache(name)
+
+        metas = np_meta(self.flags.num, self.itemsize, 0, self.shape, self.strides, self.dtype.kind,
+                        self.dtype.byteorder)
+
+        self._build_args = self.args(self.storage_id, self._class_name, self._get_name(), metas)
 
         if len(self.shape) != 0:
-            self._hcache.save_numpy([self.storage_id], [self])
+            self._hcache.save_numpy(self.storage_id, self, self._build_args.metas)
         StorageNumpy._store_meta(self._build_args)
 
     def stop_persistent(self):
@@ -186,7 +185,7 @@ class StorageNumpy(IStorage, np.ndarray):
             return
 
         if self.storage_id and len(self.shape):
-            self._hcache.save_numpy([self.storage_id], [self])
+            self._hcache.save_numpy(self.storage_id, self, self._build_args.metas)
 
         if ufunc.nout == 1:
             results = (results,)

--- a/hecuba_py/hecuba/hnumpy.py
+++ b/hecuba_py/hecuba/hnumpy.py
@@ -67,6 +67,14 @@ class StorageNumpy(IStorage, np.ndarray):
     def __array_finalize__(self, obj):
         if obj is None:
             return
+        self.storage_id = getattr(obj, "storage_id", None)
+        self._hcache = getattr(obj, "_hcache", None)
+        self._build_args = getattr(obj, "_build_args", None)
+        try:
+            name = obj._get_name()
+            self._set_name(name)
+        except AttributeError:
+            pass
 
     @staticmethod
     def _create_tables(name):

--- a/hecuba_py/tests/withcassandra/storagenumpy_tests.py
+++ b/hecuba_py/tests/withcassandra/storagenumpy_tests.py
@@ -126,5 +126,25 @@ class StorageNumpyTest(unittest.TestCase):
         self.assertTrue(np.allclose(chunk.view(np.ndarray), test_numpy))
 
 
+    def test_mulitply(self):
+        nelem = 2 ** 10
+        elem_dim = 2 ** 5
+
+        storage_id = uuid.uuid3(uuid.NAMESPACE_DNS, "test_mult")
+        base_array = np.arange(nelem).reshape((elem_dim, elem_dim))
+        casted = StorageNumpy(input_array=base_array, name="testing_arrays.test_mult", storage_id=storage_id)
+        import gc
+        del casted
+        gc.collect()
+        test_numpy = np.arange(nelem).reshape((elem_dim, elem_dim))
+        casted = StorageNumpy(name="testing_arrays.test_mult", storage_id=storage_id)
+        chunk = casted[slice(None, None, None)]
+        result = np.multiply(chunk, base_array)
+        result2 = np.multiply(base_array, chunk)
+        result3 = np.multiply(base_array, base_array)
+        self.assertTrue(np.array_equal(result, result2))
+        self.assertTrue(np.array_equal(result3, result3))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/hecuba_py/tests/withcassandra/storageobj_tests.py
+++ b/hecuba_py/tests/withcassandra/storageobj_tests.py
@@ -782,12 +782,12 @@ class StorageObjTest(unittest.TestCase):
 
     def test_numpy_persistent(self):
         config.session.execute("DROP TABLE IF EXISTS my_app.TestStorageObjNumpy")
-        config.session.execute("DROP TABLE IF EXISTS my_app.teststorageobjnumpy_mynumpy_numpies")
+        config.session.execute("DROP TABLE IF EXISTS my_app.teststorageobjnumpy_mynumpy")
         my_so = TestStorageObjNumpy('tnp')
 
     def test_numpy_set(self):
         config.session.execute("DROP TABLE IF EXISTS my_app.TestStorageObjNumpy")
-        config.session.execute("DROP TABLE IF EXISTS my_app.teststorageobjnumpy_mynumpy_numpies")
+        config.session.execute("DROP TABLE IF EXISTS my_app.teststorageobjnumpy_mynumpy")
         my_so = TestStorageObjNumpy()
         my_so.mynumpy = np.random.rand(3, 2)
         my_so.make_persistent('mynewso')
@@ -795,7 +795,7 @@ class StorageObjTest(unittest.TestCase):
     def test_numpy_get(self):
         config.session.execute("DROP TABLE IF EXISTS my_app.TestStorageObjNumpy")
         config.session.execute("DROP TABLE IF EXISTS my_app.TestStorageObjNumpy_mynumpy")
-        config.session.execute("DROP TABLE IF EXISTS my_app.teststorageobjnumpy_mynumpy_numpies")
+        config.session.execute("DROP TABLE IF EXISTS my_app.teststorageobjnumpy_mynumpy")
         my_so = TestStorageObjNumpy('mynewso')
         mynumpy = np.random.rand(3, 2)
         my_so.mynumpy = mynumpy
@@ -804,32 +804,32 @@ class StorageObjTest(unittest.TestCase):
 
     def test_numpy_topersistent(self):
         config.session.execute("DROP TABLE IF EXISTS my_app.TestStorageObjNumpy")
-        config.session.execute("DROP TABLE IF EXISTS my_app.teststorageobjnumpy_mynumpy_numpies")
+        config.session.execute("DROP TABLE IF EXISTS my_app.teststorageobjnumpy_mynumpy")
         my_so = TestStorageObjNumpy()
         my_so.mynumpy = np.random.rand(3, 2)
         my_so.make_persistent('mynewso')
 
     def test_numpydict_persistent(self):
         config.session.execute("DROP TABLE IF EXISTS my_app.TestStorageObjNumpy")
-        config.session.execute("DROP TABLE IF EXISTS my_app.teststorageobjnumpy_mynumpy_numpies")
+        config.session.execute("DROP TABLE IF EXISTS my_app.teststorageobjnumpy_mynumpy")
         my_so = TestStorageObjNumpyDict('mynewso')
 
     def test_numpydict_set(self):
         config.session.execute("DROP TABLE IF EXISTS my_app.TestStorageObjNumpy")
-        config.session.execute("DROP TABLE IF EXISTS my_app.teststorageobjnumpy_mynumpy_numpies")
+        config.session.execute("DROP TABLE IF EXISTS my_app.teststorageobjnumpy_mynumpy")
         my_so = TestStorageObjNumpyDict('mynewso')
         my_so.mynumpydict[0] = np.random.rand(3, 2)
 
     def test_numpydict_to_persistent(self):
         config.session.execute("DROP TABLE IF EXISTS my_app.TestStorageObjNumpy")
-        config.session.execute("DROP TABLE IF EXISTS my_app.teststorageobjnumpy_mynumpy_numpies")
+        config.session.execute("DROP TABLE IF EXISTS my_app.teststorageobjnumpy_mynumpy")
         my_so = TestStorageObjNumpyDict()
         my_so.mynumpydict[0] = np.random.rand(3, 2)
         my_so.make_persistent('mynewso')
 
     def test_numpydict_get(self):
         config.session.execute("DROP TABLE IF EXISTS my_app.TestStorageObjNumpy")
-        config.session.execute("DROP TABLE IF EXISTS my_app.teststorageobjnumpy_mynumpy_numpies")
+        config.session.execute("DROP TABLE IF EXISTS my_app.teststorageobjnumpy_mynumpy")
         my_so = TestStorageObjNumpyDict()
         mynumpydict = np.random.rand(3, 2)
         my_so.mynumpydict[0] = mynumpydict
@@ -840,7 +840,7 @@ class StorageObjTest(unittest.TestCase):
 
     def test_numpy_operations(self):
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso")
-        config.session.execute("DROP TABLE IF EXISTS my_app.mynewso_mynumpy_numpies")
+        config.session.execute("DROP TABLE IF EXISTS my_app.mynewso_mynumpy")
         my_so = TestStorageObjNumpy()
         base_numpy = np.arange(2048)
         my_so.mynumpy = np.arange(2048)
@@ -855,7 +855,7 @@ class StorageObjTest(unittest.TestCase):
 
     def test_numpy_ops_persistent(self):
         config.session.execute("DROP TABLE IF EXISTS my_app.mynewso2")
-        config.session.execute("DROP TABLE IF EXISTS my_app.mynewso2_mynumpy_numpies")
+        config.session.execute("DROP TABLE IF EXISTS my_app.mynewso2_mynumpy")
         my_so = TestStorageObjNumpy()
         base_numpy = np.arange(2048)
         my_so.mynumpy = np.arange(2048)
@@ -897,7 +897,7 @@ class StorageObjTest(unittest.TestCase):
         a = no.mynumpy
 
         final_name_so = no._ksp + '.' + no._table
-        final_name_np = no.mynumpy._ksp + '.' + no.mynumpy._table + '_numpies'
+        final_name_np = no.mynumpy._ksp + '.' + no.mynumpy._table
         self.assertEqual(initial_name_so, final_name_so)
         self.assertEqual(initial_name_np, final_name_np)
 


### PR DESCRIPTION
Numpy arrays have attributes that we did not store (e.g. strides). Also, we store and retrieve the metadatas only from the Python side (we had that duplicated in C++ and Python). Also, general numpy code cleaning.


## Background

The numpy metadata changes between Python (`__array_interface__`) and C (`PyArrayInterface`). The same information is presented in different formats and there is no 1-to-1 easy mapping. Besides, on the C side they use aliases of C types, which makes less intuitive the structure. Thus, mapping the ArrayInterface to Cassandra from both C and Python would be a nightmare (to have a common format).

