### PR TITLE
Integrate array metas

### DIFF
--- a/hecuba_core/src/ArrayDataStore.cpp
+++ b/hecuba_core/src/ArrayDataStore.cpp
@@ -36,7 +36,7 @@ ArrayDataStore::~ArrayDataStore() {
  * @param np_metas ndarray characteristics
  * @param numpy to be saved into storage
  */
-void ArrayDataStore::store(const uint64_t *storage_id, ArrayMetadata *metadata, void *data) const {
+void ArrayDataStore::store(const uint64_t *storage_id, ArrayMetadata &metadata, void *data) const {
 
     SpaceFillingCurve::PartitionGenerator *partitions_it = this->partitioner.make_partitions_generator(metadata, data);
 
@@ -83,7 +83,7 @@ void ArrayDataStore::store(const uint64_t *storage_id, ArrayMetadata *metadata, 
  * @param storage_id of the array to retrieve
  * @return Numpy ndarray as a Python object
  */
-void *ArrayDataStore::read(const uint64_t *storage_id, ArrayMetadata *metadata) const {
+void *ArrayDataStore::read(const uint64_t *storage_id, ArrayMetadata &metadata) const {
 
     std::shared_ptr<const std::vector<ColumnMeta> > keys_metas = read_cache->get_metadata()->get_keys();
     uint32_t keys_size = (*--keys_metas->end()).size + (*--keys_metas->end()).position;
@@ -114,7 +114,8 @@ void *ArrayDataStore::read(const uint64_t *storage_id, ArrayMetadata *metadata) 
         //Cluster id
         memcpy(buffer + offset, &cluster_id, sizeof(cluster_id));
         //We fetch the data
-        result = read_cache->get_crow(new TupleRow(keys_metas, keys_size, buffer));
+        const TupleRow *tr = new TupleRow(keys_metas, keys_size, buffer);
+        result = read_cache->get_crow(tr);
         //build cluster
         all_results.insert(all_results.end(), result.begin(), result.end());
         for (const TupleRow *row:result) {

--- a/hecuba_core/src/ArrayDataStore.h
+++ b/hecuba_core/src/ArrayDataStore.h
@@ -21,13 +21,6 @@ public:
 
     void *read(const uint64_t *storage_id, ArrayMetadata &metadata) const;
 
-    // Returns the metadata of the array identified by the storage_id
-    //ArrayMetadata *read_metadata(const uint64_t *storage_id) const;
-
-    // Overwrite the metadata of the array identified by the given storage_id
-    //void update_metadata(const uint64_t *storage_id, ArrayMetadata &metadata) const;
-
-
 protected:
 
 

--- a/hecuba_core/src/ArrayDataStore.h
+++ b/hecuba_core/src/ArrayDataStore.h
@@ -17,15 +17,15 @@ public:
 
     ~ArrayDataStore();
 
-    void store(const uint64_t *storage_id, ArrayMetadata *metadata, void *data) const;
+    void store(const uint64_t *storage_id, ArrayMetadata &metadata, void *data) const;
 
-    void *read(const uint64_t *storage_id, ArrayMetadata *metadata) const;
+    void *read(const uint64_t *storage_id, ArrayMetadata &metadata) const;
 
     // Returns the metadata of the array identified by the storage_id
-    ArrayMetadata *read_metadata(const uint64_t *storage_id) const;
+    //ArrayMetadata *read_metadata(const uint64_t *storage_id) const;
 
     // Overwrite the metadata of the array identified by the given storage_id
-    void update_metadata(const uint64_t *storage_id, ArrayMetadata *metadata) const;
+    //void update_metadata(const uint64_t *storage_id, ArrayMetadata &metadata) const;
 
 
 protected:

--- a/hecuba_core/src/SpaceFillingCurve.cpp
+++ b/hecuba_core/src/SpaceFillingCurve.cpp
@@ -9,20 +9,17 @@
  * @return
  */
 SpaceFillingCurve::PartitionGenerator *
-SpaceFillingCurve::make_partitions_generator(const ArrayMetadata *metas, void *data) {
-    if (!metas) throw ModuleException("Array metadata not present");
-    if (metas->partition_type == ZORDER_ALGORITHM) return new ZorderCurveGenerator(metas, data);
+SpaceFillingCurve::make_partitions_generator(const ArrayMetadata &metas, void *data) {
+    if (metas.partition_type == ZORDER_ALGORITHM) return new ZorderCurveGenerator(metas, data);
     return new SpaceFillingGenerator(metas, data);
 }
 
 
-SpaceFillingCurve::SpaceFillingGenerator::SpaceFillingGenerator() : done(true) {}
-
-SpaceFillingCurve::SpaceFillingGenerator::SpaceFillingGenerator(const ArrayMetadata *metas, void *data) : done(false),
+SpaceFillingCurve::SpaceFillingGenerator::SpaceFillingGenerator(const ArrayMetadata &metas, void *data) : done(false),
                                                                                                           metas(metas),
                                                                                                           data(data) {
-    total_size = metas->elem_size;
-    for (uint32_t dim:metas->dims) total_size *= dim;
+    total_size = metas.elem_size;
+    for (uint32_t dim:metas.dims) total_size *= dim;
 }
 
 Partition SpaceFillingCurve::SpaceFillingGenerator::getNextPartition() {
@@ -45,10 +42,10 @@ int32_t SpaceFillingCurve::SpaceFillingGenerator::computeNextClusterId() {
 }
 
 void *
-SpaceFillingCurve::SpaceFillingGenerator::merge_partitions(const ArrayMetadata *metas, std::vector<Partition> chunks) {
-    uint64_t arrsize = metas->elem_size;
+SpaceFillingCurve::SpaceFillingGenerator::merge_partitions(const ArrayMetadata &metas, std::vector<Partition> chunks) {
+    uint64_t arrsize = metas.elem_size;
 
-    for (uint32_t dim:metas->dims) arrsize *= dim;
+    for (uint32_t dim:metas.dims) arrsize *= dim;
 
     char *data = (char *) malloc(arrsize);
     uint64_t block_size = arrsize; //metas->block_size;
@@ -63,28 +60,26 @@ SpaceFillingCurve::SpaceFillingGenerator::merge_partitions(const ArrayMetadata *
 
 /*** Zorder (morton encoding) algorithms ***/
 
-ZorderCurveGenerator::ZorderCurveGenerator() : done(true) {}
-
-ZorderCurveGenerator::ZorderCurveGenerator(const ArrayMetadata *metas, void *data) : done(false), metas(metas),
+ZorderCurveGenerator::ZorderCurveGenerator(const ArrayMetadata &metas, void *data) : done(false), metas(metas),
                                                                                      data(data) {
 
-    ndims = (uint32_t) metas->dims.size();
+    ndims = (uint32_t) metas.dims.size();
     //Compute the best fitting block
     //Make the block size multiple of the element size
-    block_size = BLOCK_SIZE - (BLOCK_SIZE % metas->elem_size);
+    block_size = BLOCK_SIZE - (BLOCK_SIZE % metas.elem_size);
     //Compute the max number of elements per dimension as the ndims root of the block size
-    row_elements = (uint32_t) std::floor(pow(block_size / metas->elem_size, (1.0 / ndims)));
+    row_elements = (uint32_t) std::floor(pow(block_size / metas.elem_size, (1.0 / ndims)));
     //TODO nth root returns an approximated value, which is later truncated by floor
     // Example: 125^(1.0/3) returns 4.9 -> 4: Correct is 5
 
     //Compute the final block size
-    block_size = (uint64_t) pow(row_elements, ndims) * metas->elem_size;
+    block_size = (uint64_t) pow(row_elements, ndims) * metas.elem_size;
 
     //Compute the number of blocks
     nblocks = 1;
     blocks_dim = std::vector<uint32_t>(ndims);
     for (uint32_t dim = 0; dim < ndims; ++dim) {
-        blocks_dim[dim] = (uint32_t) std::ceil((double) metas->dims[dim] / row_elements);
+        blocks_dim[dim] = (uint32_t) std::ceil((double) metas.dims[dim] / row_elements);
         nblocks *= blocks_dim[dim];
     }
 
@@ -215,10 +210,10 @@ Partition ZorderCurveGenerator::getNextPartition() {
     }
 
     //Number of elements to skip until the coordinates
-    uint64_t offset = getIdFromIndexes(metas->dims, block_ccs);
+    uint64_t offset = getIdFromIndexes(metas.dims, block_ccs);
 
     //Compute the real offset as: position inside the array * sizeof(element)
-    char *input_start = ((char *) data) + offset * metas->elem_size;
+    char *input_start = ((char *) data) + offset * metas.elem_size;
 
     if (!bound) {
         //In this case the block has size of row_elements in every_dimension
@@ -230,13 +225,13 @@ Partition ZorderCurveGenerator::getNextPartition() {
         output_data += sizeof(uint64_t);
         output_data_end = output_data + block_size;
         //Copy the data
-        tessellate(metas->dims, block_dims, metas->elem_size, input_start, output_data, output_data_end);
+        tessellate(metas.dims, block_dims, metas.elem_size, input_start, output_data, output_data_end);
 
     } else {
         //The block is a limit of the array, and its size needs to be recomputed and adjusted
 
         //compute block size
-        uint64_t bound_size = metas->elem_size;
+        uint64_t bound_size = metas.elem_size;
         for (uint32_t i = 0; i < ndims; ++i) {
             //compute elem per dimension to be copied
             if (block_ccs[i] / row_elements != (blocks_dim[i] - 1)) {
@@ -244,7 +239,7 @@ Partition ZorderCurveGenerator::getNextPartition() {
                 bound_dims[i] = row_elements;
             } else {
                 //Is a limit, copy the remaining elements
-                bound_dims[i] = (metas->dims[i] - (blocks_dim[i] - 1) * row_elements);
+                bound_dims[i] = (metas.dims[i] - (blocks_dim[i] - 1) * row_elements);
             }
             bound_size *= bound_dims[i];
         }
@@ -257,7 +252,7 @@ Partition ZorderCurveGenerator::getNextPartition() {
         output_data += sizeof(uint64_t);
         output_data_end = output_data + bound_size;
         //Copy the data
-        tessellate(metas->dims, bound_dims, metas->elem_size, input_start, output_data, output_data_end);
+        tessellate(metas.dims, bound_dims, metas.elem_size, input_start, output_data, output_data_end);
     }
 
     ++block_counter;
@@ -325,27 +320,27 @@ void ZorderCurveGenerator::copy_block_to_array(std::vector<uint32_t> dims, std::
 }
 
 
-void *ZorderCurveGenerator::merge_partitions(const ArrayMetadata *metas, std::vector<Partition> chunks) {
-    uint32_t ndims = (uint32_t) metas->dims.size();
+void *ZorderCurveGenerator::merge_partitions(const ArrayMetadata &metas, std::vector<Partition> chunks) {
+    uint32_t ndims = (uint32_t) metas.dims.size();
 
     //Compute the best fitting block
     //Make the block size multiple of the element size
-    uint64_t block_size = BLOCK_SIZE - (BLOCK_SIZE % metas->elem_size);
+    uint64_t block_size = BLOCK_SIZE - (BLOCK_SIZE % metas.elem_size);
     //Compute the max number of elements per dimension as the ndims root of the block size
-    uint32_t row_elements = (uint32_t) std::floor(pow(block_size / metas->elem_size, (1.0 / ndims)));
+    uint32_t row_elements = (uint32_t) std::floor(pow(block_size / metas.elem_size, (1.0 / ndims)));
     //TODO nth root returns an approximated value, which is later truncated by floor
     // Example: 125^(1.0/3) returns 4.9 -> 4: Correct is 5
 
     //Compute the final block size
-    block_size = (uint64_t) pow(row_elements, ndims) * metas->elem_size;
+    block_size = (uint64_t) pow(row_elements, ndims) * metas.elem_size;
 
     //Compute the number of blocks and the final size of the array
     //Save the highest number of blocks for a dimension to later compute the maximum ZorderId
-    uint64_t total_size = metas->elem_size;
+    uint64_t total_size = metas.elem_size;
     std::vector<uint32_t> blocks_dim(ndims);
     for (uint32_t dim = 0; dim < ndims; ++dim) {
-        total_size *= metas->dims[dim];
-        blocks_dim[dim] = (uint32_t) std::ceil((double) metas->dims[dim] / row_elements);
+        total_size *= metas.dims[dim];
+        blocks_dim[dim] = (uint32_t) std::ceil((double) metas.dims[dim] / row_elements);
     }
 
 
@@ -372,8 +367,8 @@ void *ZorderCurveGenerator::merge_partitions(const ArrayMetadata *metas, std::ve
         }
 
         //Number of elements to skip until the coordinates
-        uint64_t offset = getIdFromIndexes(metas->dims, ccs);
-        char *output_start = data + offset * metas->elem_size;
+        uint64_t offset = getIdFromIndexes(metas.dims, ccs);
+        char *output_start = data + offset * metas.elem_size;
         char *input = (char *) chunk.data;
         uint64_t *retrieved_block_size = (uint64_t *) input;
         input += +sizeof(uint64_t);
@@ -387,7 +382,7 @@ void *ZorderCurveGenerator::merge_partitions(const ArrayMetadata *metas, std::ve
                                       "the size of blocks while merging them into an array");
 
 
-            copy_block_to_array(metas->dims, block_shape, metas->elem_size, output_start, input, input_ends);
+            copy_block_to_array(metas.dims, block_shape, metas.elem_size, output_start, input, input_ends);
 
 
         } else {
@@ -395,7 +390,7 @@ void *ZorderCurveGenerator::merge_partitions(const ArrayMetadata *metas, std::ve
             //The block is a limit of the array, and its size needs to be recomputed and adjusted
             std::vector<uint32_t> bound_dims(ndims);
             //compute block size
-            uint64_t bound_size = metas->elem_size;
+            uint64_t bound_size = metas.elem_size;
             for (uint32_t i = 0; i < ndims; ++i) {
                 //compute elem per dimension to be copied
                 if (ccs[i] / row_elements != (blocks_dim[i] - 1)) {
@@ -403,13 +398,13 @@ void *ZorderCurveGenerator::merge_partitions(const ArrayMetadata *metas, std::ve
                     bound_dims[i] = (int32_t) row_elements;
                 } else {
                     //Is a limit, copy the remaining elements
-                    bound_dims[i] = (uint32_t) (metas->dims[i] - (blocks_dim[i] - 1) * row_elements);
+                    bound_dims[i] = (uint32_t) (metas.dims[i] - (blocks_dim[i] - 1) * row_elements);
                 }
                 bound_size *= bound_dims[i];
             }
 
             //Copy the data
-            copy_block_to_array(metas->dims, bound_dims, metas->elem_size, output_start, input, input_ends);
+            copy_block_to_array(metas.dims, bound_dims, metas.elem_size, output_start, input, input_ends);
         }
     }
     return data;

--- a/hecuba_core/src/SpaceFillingCurve.h
+++ b/hecuba_core/src/SpaceFillingCurve.h
@@ -64,22 +64,21 @@ public:
 
         virtual int32_t computeNextClusterId() = 0;
 
-        virtual void *merge_partitions(const ArrayMetadata *metas, std::vector<Partition> chunks) = 0;
+        virtual void *merge_partitions(const ArrayMetadata &metas, std::vector<Partition> chunks) = 0;
 
     };
 
 
     ~SpaceFillingCurve() {};
 
-    static PartitionGenerator *make_partitions_generator(const ArrayMetadata *metas, void *data);
+    static PartitionGenerator *make_partitions_generator(const ArrayMetadata &metas, void *data);
 
 protected:
 
     class SpaceFillingGenerator : public PartitionGenerator {
     public:
-        SpaceFillingGenerator();
 
-        SpaceFillingGenerator(const ArrayMetadata *metas, void *data);
+        SpaceFillingGenerator(const ArrayMetadata &metas, void *data);
 
         Partition getNextPartition();
 
@@ -87,11 +86,11 @@ protected:
 
         bool isDone() { return done; };
 
-        void *merge_partitions(const ArrayMetadata *metas, std::vector<Partition> chunks);
+        void *merge_partitions(const ArrayMetadata &metas, std::vector<Partition> chunks);
 
     protected:
         bool done;
-        const ArrayMetadata *metas;
+        const ArrayMetadata metas;
         void *data;
         uint64_t total_size;
     };
@@ -101,9 +100,8 @@ protected:
 
 class ZorderCurveGenerator : public SpaceFillingCurve::PartitionGenerator {
 public:
-    ZorderCurveGenerator();
 
-    ZorderCurveGenerator(const ArrayMetadata *metas, void *data);
+    ZorderCurveGenerator(const ArrayMetadata &metas, void *data);
 
     Partition getNextPartition();
 
@@ -122,11 +120,11 @@ public:
 
     uint64_t getIdFromIndexes(const std::vector<uint32_t> &dims, const std::vector<uint32_t> &indexes);
 
-    void *merge_partitions(const ArrayMetadata *metas, std::vector<Partition> chunks);
+    void *merge_partitions(const ArrayMetadata &metas, std::vector<Partition> chunks);
 
 private:
     bool done;
-    const ArrayMetadata *metas;
+    const ArrayMetadata metas;
     void *data;
     uint32_t ndims, row_elements;
     uint64_t block_size, nblocks;

--- a/hecuba_core/src/SpaceFillingCurve.h
+++ b/hecuba_core/src/SpaceFillingCurve.h
@@ -33,20 +33,10 @@ struct Partition {
 struct ArrayMetadata {
     ArrayMetadata() = default;
 
-    ArrayMetadata(std::vector<uint32_t> &dims, std::vector<uint32_t> &strides, uint32_t elem_size,
-                  uint8_t partition_type, std::string &typekind, std::string &byteorder) {
-        this->dims = dims;
-        this->strides = strides;
-        this->elem_size = elem_size;
-        this->partition_type = partition_type;
-        this->typekind = typekind;
-        this->byteorder = byteorder;
-    }
-
     std::vector<uint32_t> dims, strides;
-    uint32_t elem_size, flags;
-    uint8_t partition_type;
-    std::string typekind, byteorder;
+    uint32_t elem_size = 0, flags = 0;
+    uint8_t partition_type = ZORDER_ALGORITHM;
+    char typekind = ' ', byteorder = ' ';
 };
 
 

--- a/hecuba_core/src/StorageInterface.h
+++ b/hecuba_core/src/StorageInterface.h
@@ -61,6 +61,7 @@ public:
                            config_map &config);
 
     inline CassSession *get_session() {
+        if (!this->session) throw ModuleException("Cassandra not connected yet, session unavailable");
         return this->session;
     }
 

--- a/hecuba_core/src/py_interface/HCache.cpp
+++ b/hecuba_core/src/py_interface/HCache.cpp
@@ -628,7 +628,6 @@ static int harray_metadata_init(HArrayMetadata *self, PyObject *args, PyObject *
 
 
 // Dims and ndims
-
     if (!PyList_Check(dims)) throw ModuleException("numpy metadata missing dims");
     int32_t ndims = PyList_Size(dims);
     self->np_metas.dims.resize(ndims);
@@ -641,7 +640,6 @@ static int harray_metadata_init(HArrayMetadata *self, PyObject *args, PyObject *
         if (!PyLong_Check(elem_dim) || !PyArg_Parse(elem_dim, Py_INT, &self->np_metas.dims[dim_i]))
             throw ModuleException("Numpy dims must be a list of ints");
     }
-    //Py_DECREF(dims);
 
 
 // Strides
@@ -655,7 +653,6 @@ static int harray_metadata_init(HArrayMetadata *self, PyObject *args, PyObject *
             throw ModuleException("Numpy strides must be a list of ints");
     }
 
-    //Py_DECREF(dims);
     self->np_metas.typekind = typekind_tmp[0];
     self->np_metas.byteorder = byteorder_tmp[0];
 

--- a/hecuba_core/src/py_interface/HCache.cpp
+++ b/hecuba_core/src/py_interface/HCache.cpp
@@ -439,7 +439,7 @@ static PyObject *save_numpy(HNumpyStore *self, PyObject *args) {
     }
 
     const uint64_t *storage_id = parse_uuid(py_storage_id);
-    ArrayMetadata *metas;
+    ArrayMetadata metas;
 
     try {
         metas = self->NumpyDataStore->make_metadata(py_np_metas);
@@ -467,7 +467,6 @@ static PyObject *save_numpy(HNumpyStore *self, PyObject *args) {
         return NULL;
     }
 
-    delete (metas);
 
     Py_RETURN_NONE;
 }
@@ -481,7 +480,7 @@ static PyObject *get_numpy(HNumpyStore *self, PyObject *args) {
 
     const uint64_t *storage_id = parse_uuid(py_storage_id);
 
-    ArrayMetadata *metas;
+    ArrayMetadata metas;
 
     try {
         metas = self->NumpyDataStore->make_metadata(py_np_metas);
@@ -502,7 +501,6 @@ static PyObject *get_numpy(HNumpyStore *self, PyObject *args) {
         return NULL;
     }
 
-    delete (metas);
     // Wrap the numpy into a list to follow the standard format of Hecuba
     return numpy;
 }
@@ -1255,6 +1253,7 @@ PyInit_hfetch(void) {
     PyModule_AddObject(m, "HIterator", (PyObject * ) & hfetch_HIterType);
     PyModule_AddObject(m, "HWriter", (PyObject * ) & hfetch_HWriterType);
     PyModule_AddObject(m, "HNumpyStore", (PyObject * ) & hfetch_HNumpyStoreType);
+    //PyModule_AddObject(m, "HArrayMetadata", (PyObject * ) & hfetch_HArrayMetadataType);
     if (_import_array() < 0) {
         PyErr_Print();
         PyErr_SetString(PyExc_ImportError, "numpy.core.multiarray failed to import");

--- a/hecuba_core/src/py_interface/HCache.h
+++ b/hecuba_core/src/py_interface/HCache.h
@@ -2,16 +2,18 @@
 #define PREFETCHER_PREFETCHER_IMP_H
 
 #define PY_SSIZE_T_CLEAN
+
 #include <Python.h>
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #define PY_ARRAY_UNIQUE_SYMBOL cool_ARRAY_API
 
 #if __cplusplus <= 199711L
-  #error This library needs at least a C++11 compliant compiler
+#error This library needs at least a C++11 compliant compiler
 #endif
 
 #include "numpy/arrayobject.h"
+#include <structmember.h>
 
 
 #include <tuple>
@@ -66,6 +68,11 @@ typedef struct {
     PyObject_HEAD
     NumpyStorage *NumpyDataStore;
 } HNumpyStore;
+
+typedef struct {
+    PyObject_HEAD
+    ArrayMetadata np_metas;
+} HArrayMetadata;
 
 
 static PyObject *create_iter_keys(HCache *self, PyObject *args);

--- a/hecuba_core/src/py_interface/NumpyStorage.cpp
+++ b/hecuba_core/src/py_interface/NumpyStorage.cpp
@@ -34,7 +34,7 @@ PyObject *NumpyStorage::read_numpy(const uint64_t *storage_id, ArrayMetadata &np
         dims[i] = np_metas.dims[i];
     }
 
-    int32_t type = PyArray_TypestrConvert(np_metas.elem_size, np_metas.typekind[0]);
+    int32_t type = PyArray_TypestrConvert(np_metas.elem_size, np_metas.typekind);
     if (type == NPY_NOTYPE)
         throw ModuleException("Can't identify Numpy dtype from typekind");
 
@@ -54,100 +54,3 @@ PyObject *NumpyStorage::read_numpy(const uint64_t *storage_id, ArrayMetadata &np
     return resulting_array;
 }
 
-
-ArrayMetadata NumpyStorage::make_metadata(PyObject *py_np_metas) const {
-
-    const char *expected = "np_meta"; //hecuba.hnumpy.StorageNumpy.
-    if (strlen(py_np_metas->ob_type->tp_name) != strlen(expected) ||
-        memcmp(py_np_metas->ob_type->tp_name, expected, strlen(expected)) != 0) {
-        PyErr_SetString(PyExc_ValueError, "Numpy metadata class does not match the expected");
-        std::cerr << py_np_metas->ob_type->tp_name << std::endl;
-        throw ModuleException("Numpy metadata class does not match the expected");
-    }
-
-    ArrayMetadata np_meta = ArrayMetadata();
-
-    // elem_size (itemsize)
-    PyObject *attr = PyObject_GetAttrString(py_np_metas, "elem_size");
-    if (attr == Py_None) throw ModuleException("numpy metadata missing elem_size");
-    if (!PyLong_Check(attr) || !PyArg_Parse(attr, Py_INT, &np_meta.elem_size))
-        throw ModuleException("Numpy elem_size must be an int");
-    Py_DECREF(attr);
-
-
-
-    // Dims and ndims
-    attr = PyObject_GetAttrString(py_np_metas, "dims");
-    if (attr == Py_None || !PyList_Check(attr)) throw ModuleException("numpy metadata missing dims");
-    int32_t ndims = PyList_Size(attr);
-    np_meta.dims.resize(ndims);
-    np_meta.strides.resize(ndims);
-
-
-    for (uint32_t dim_i = 0; dim_i < ndims; ++dim_i) {
-        PyObject *elem_dim = PyList_GetItem(attr, dim_i);
-        if (elem_dim == Py_None) throw ModuleException("numpy metadata missing dims");
-        if (!PyLong_Check(elem_dim) || !PyArg_Parse(elem_dim, Py_INT, &np_meta.dims[dim_i]))
-            throw ModuleException("Numpy dims must be a list of ints");
-    }
-    Py_DECREF(attr);
-
-
-    // Strides
-    attr = PyObject_GetAttrString(py_np_metas, "strides");
-    if (attr == Py_None || !PyList_Check(attr)) throw ModuleException("numpy metadata missing strides");
-    else {
-        if (PyList_Size(attr) != ndims) throw ModuleException("Numpy strides must be a list of ints");
-        for (uint32_t dim_i = 0; dim_i < ndims; ++dim_i) {
-            PyObject *elem_dim = PyList_GetItem(attr, dim_i);
-            if (elem_dim == Py_None) throw ModuleException("numpy metadata missing strides");
-            if (!PyLong_Check(elem_dim) || !PyArg_Parse(elem_dim, Py_INT, &np_meta.strides[dim_i]))
-                throw ModuleException("Numpy strides must be a list of ints");
-        }
-    }
-    Py_DECREF(attr);
-
-
-    // Typekind (gentype) != typecode
-    attr = PyObject_GetAttrString(py_np_metas, "typekind");
-    if (attr == Py_None) throw ModuleException("numpy metadata missing typekind");
-
-    if (PyUnicode_Check(attr)) {
-        Py_ssize_t l_size;
-        const char *l_temp = PyUnicode_AsUTF8AndSize(attr, &l_size);
-        if (!l_temp)
-            throw ModuleException("Numpy typekind must be UTF8");
-        np_meta.typekind = std::string(l_temp, l_size + 1);
-    }
-    Py_DECREF(attr);
-
-    // Byteorder
-    attr = PyObject_GetAttrString(py_np_metas, "byteorder");
-    if (attr == Py_None) throw ModuleException("numpy metadata missing byteorder");
-
-    if (PyUnicode_Check(attr)) {
-        Py_ssize_t l_size;
-        const char *l_temp = PyUnicode_AsUTF8AndSize(attr, &l_size);
-        if (!l_temp)
-            throw ModuleException("Byteorder must be UTF8");
-        np_meta.byteorder = std::string(l_temp, l_size + 1);
-    }
-    Py_DECREF(attr);
-
-
-    // Flags
-    attr = PyObject_GetAttrString(py_np_metas, "flags");
-    if (attr == Py_None) np_meta.flags = 0;
-    else if (!PyLong_Check(attr) || !PyArg_Parse(attr, Py_INT, &np_meta.flags))
-        throw ModuleException("Numpy flgs must be an int");
-    Py_DECREF(attr);
-
-    // Partition algorithm
-    attr = PyObject_GetAttrString(py_np_metas, "partition_type");
-    if (attr == Py_None) np_meta.partition_type = NO_PARTITIONS;
-    else if (!PyLong_Check(attr) || !PyArg_Parse(attr, Py_SHORT_INT, &np_meta.partition_type))
-        throw ModuleException("Numpy partition type must be an int");
-    Py_DECREF(attr);
-
-    return np_meta;
-}

--- a/hecuba_core/src/py_interface/NumpyStorage.cpp
+++ b/hecuba_core/src/py_interface/NumpyStorage.cpp
@@ -14,7 +14,7 @@ NumpyStorage::~NumpyStorage() {
 };
 
 
-void NumpyStorage::store_numpy(const uint64_t *storage_id, PyArrayObject *numpy, ArrayMetadata *np_metas) const {
+void NumpyStorage::store_numpy(const uint64_t *storage_id, PyArrayObject *numpy, ArrayMetadata &np_metas) const {
     void *data = PyArray_BYTES(numpy);
     this->store(storage_id, np_metas, data);
 }
@@ -26,21 +26,21 @@ void NumpyStorage::store_numpy(const uint64_t *storage_id, PyArrayObject *numpy,
  * @param np_metas array description
  * @return Numpy ndarray as a Python object
  */
-PyObject *NumpyStorage::read_numpy(const uint64_t *storage_id, ArrayMetadata *np_metas) {
+PyObject *NumpyStorage::read_numpy(const uint64_t *storage_id, ArrayMetadata &np_metas) {
     void *data = this->read(storage_id, np_metas);
 
-    npy_intp *dims = new npy_intp[np_metas->dims.size()];
-    for (uint32_t i = 0; i < np_metas->dims.size(); ++i) {
-        dims[i] = np_metas->dims[i];
+    npy_intp *dims = new npy_intp[np_metas.dims.size()];
+    for (uint32_t i = 0; i < np_metas.dims.size(); ++i) {
+        dims[i] = np_metas.dims[i];
     }
 
-    int32_t type = PyArray_TypestrConvert(np_metas->elem_size, np_metas->typekind[0]);
+    int32_t type = PyArray_TypestrConvert(np_metas.elem_size, np_metas.typekind[0]);
     if (type == NPY_NOTYPE)
         throw ModuleException("Can't identify Numpy dtype from typekind");
 
     PyObject *resulting_array;
     try {
-        resulting_array = PyArray_SimpleNewFromData((int32_t) np_metas->dims.size(), dims, type, data);
+        resulting_array = PyArray_SimpleNewFromData((int32_t) np_metas.dims.size(), dims, type, data);
 
         PyArrayObject *converted_array;
         PyArray_OutputConverter(resulting_array, &converted_array);
@@ -55,22 +55,22 @@ PyObject *NumpyStorage::read_numpy(const uint64_t *storage_id, ArrayMetadata *np
 }
 
 
-ArrayMetadata *NumpyStorage::make_metadata(PyObject *py_np_metas) const {
+ArrayMetadata NumpyStorage::make_metadata(PyObject *py_np_metas) const {
 
     const char *expected = "np_meta"; //hecuba.hnumpy.StorageNumpy.
     if (strlen(py_np_metas->ob_type->tp_name) != strlen(expected) ||
         memcmp(py_np_metas->ob_type->tp_name, expected, strlen(expected)) != 0) {
         PyErr_SetString(PyExc_ValueError, "Numpy metadata class does not match the expected");
         std::cerr << py_np_metas->ob_type->tp_name << std::endl;
-        return NULL;
+        throw ModuleException("Numpy metadata class does not match the expected");
     }
 
-    ArrayMetadata *np_meta = new ArrayMetadata();
+    ArrayMetadata np_meta = ArrayMetadata();
 
     // elem_size (itemsize)
     PyObject *attr = PyObject_GetAttrString(py_np_metas, "elem_size");
-    if (attr == Py_None) return nullptr;
-    if (!PyLong_Check(attr) || !PyArg_Parse(attr, Py_INT, &np_meta->elem_size))
+    if (attr == Py_None) throw ModuleException("numpy metadata missing elem_size");
+    if (!PyLong_Check(attr) || !PyArg_Parse(attr, Py_INT, &np_meta.elem_size))
         throw ModuleException("Numpy elem_size must be an int");
     Py_DECREF(attr);
 
@@ -78,16 +78,16 @@ ArrayMetadata *NumpyStorage::make_metadata(PyObject *py_np_metas) const {
 
     // Dims and ndims
     attr = PyObject_GetAttrString(py_np_metas, "dims");
-    if (attr == Py_None || !PyList_Check(attr)) return nullptr;
+    if (attr == Py_None || !PyList_Check(attr)) throw ModuleException("numpy metadata missing dims");
     int32_t ndims = PyList_Size(attr);
-    np_meta->dims.resize(ndims);
-    np_meta->strides.resize(ndims);
+    np_meta.dims.resize(ndims);
+    np_meta.strides.resize(ndims);
 
 
     for (uint32_t dim_i = 0; dim_i < ndims; ++dim_i) {
         PyObject *elem_dim = PyList_GetItem(attr, dim_i);
-        if (elem_dim == Py_None) return nullptr;
-        if (!PyLong_Check(elem_dim) || !PyArg_Parse(elem_dim, Py_INT, &np_meta->dims[dim_i]))
+        if (elem_dim == Py_None) throw ModuleException("numpy metadata missing dims");
+        if (!PyLong_Check(elem_dim) || !PyArg_Parse(elem_dim, Py_INT, &np_meta.dims[dim_i]))
             throw ModuleException("Numpy dims must be a list of ints");
     }
     Py_DECREF(attr);
@@ -95,13 +95,13 @@ ArrayMetadata *NumpyStorage::make_metadata(PyObject *py_np_metas) const {
 
     // Strides
     attr = PyObject_GetAttrString(py_np_metas, "strides");
-    if (attr == Py_None || !PyList_Check(attr)) return nullptr;
+    if (attr == Py_None || !PyList_Check(attr)) throw ModuleException("numpy metadata missing strides");
     else {
         if (PyList_Size(attr) != ndims) throw ModuleException("Numpy strides must be a list of ints");
         for (uint32_t dim_i = 0; dim_i < ndims; ++dim_i) {
             PyObject *elem_dim = PyList_GetItem(attr, dim_i);
-            if (elem_dim == Py_None) return nullptr;
-            if (!PyLong_Check(elem_dim) || !PyArg_Parse(elem_dim, Py_INT, &np_meta->strides[dim_i]))
+            if (elem_dim == Py_None) throw ModuleException("numpy metadata missing strides");
+            if (!PyLong_Check(elem_dim) || !PyArg_Parse(elem_dim, Py_INT, &np_meta.strides[dim_i]))
                 throw ModuleException("Numpy strides must be a list of ints");
         }
     }
@@ -110,42 +110,42 @@ ArrayMetadata *NumpyStorage::make_metadata(PyObject *py_np_metas) const {
 
     // Typekind (gentype) != typecode
     attr = PyObject_GetAttrString(py_np_metas, "typekind");
-    if (attr == Py_None) return nullptr;
+    if (attr == Py_None) throw ModuleException("numpy metadata missing typekind");
 
     if (PyUnicode_Check(attr)) {
         Py_ssize_t l_size;
         const char *l_temp = PyUnicode_AsUTF8AndSize(attr, &l_size);
         if (!l_temp)
             throw ModuleException("Numpy typekind must be UTF8");
-        np_meta->typekind = std::string(l_temp, l_size + 1);
+        np_meta.typekind = std::string(l_temp, l_size + 1);
     }
     Py_DECREF(attr);
 
     // Byteorder
     attr = PyObject_GetAttrString(py_np_metas, "byteorder");
-    if (attr == Py_None) return nullptr;
+    if (attr == Py_None) throw ModuleException("numpy metadata missing byteorder");
 
     if (PyUnicode_Check(attr)) {
         Py_ssize_t l_size;
         const char *l_temp = PyUnicode_AsUTF8AndSize(attr, &l_size);
         if (!l_temp)
             throw ModuleException("Byteorder must be UTF8");
-        np_meta->byteorder = std::string(l_temp, l_size + 1);
+        np_meta.byteorder = std::string(l_temp, l_size + 1);
     }
     Py_DECREF(attr);
 
 
     // Flags
     attr = PyObject_GetAttrString(py_np_metas, "flags");
-    if (attr == Py_None) np_meta->flags = 0;
-    else if (!PyLong_Check(attr) || !PyArg_Parse(attr, Py_INT, &np_meta->flags))
+    if (attr == Py_None) np_meta.flags = 0;
+    else if (!PyLong_Check(attr) || !PyArg_Parse(attr, Py_INT, &np_meta.flags))
         throw ModuleException("Numpy flgs must be an int");
     Py_DECREF(attr);
 
     // Partition algorithm
     attr = PyObject_GetAttrString(py_np_metas, "partition_type");
-    if (attr == Py_None) np_meta->partition_type = NO_PARTITIONS;
-    else if (!PyLong_Check(attr) || !PyArg_Parse(attr, Py_SHORT_INT, &np_meta->partition_type))
+    if (attr == Py_None) np_meta.partition_type = NO_PARTITIONS;
+    else if (!PyLong_Check(attr) || !PyArg_Parse(attr, Py_SHORT_INT, &np_meta.partition_type))
         throw ModuleException("Numpy partition type must be an int");
     Py_DECREF(attr);
 

--- a/hecuba_core/src/py_interface/NumpyStorage.h
+++ b/hecuba_core/src/py_interface/NumpyStorage.h
@@ -30,7 +30,6 @@ public:
 
     PyObject *read_numpy(const uint64_t *storage_id, ArrayMetadata &np_metas);
 
-    ArrayMetadata make_metadata(PyObject *py_np_metas) const;
 };
 
 

--- a/hecuba_core/src/py_interface/NumpyStorage.h
+++ b/hecuba_core/src/py_interface/NumpyStorage.h
@@ -26,11 +26,11 @@ public:
 
     ~NumpyStorage();
 
-    void store_numpy(const uint64_t *storage_id, PyArrayObject *numpy, ArrayMetadata *) const;
+    void store_numpy(const uint64_t *storage_id, PyArrayObject *numpy, ArrayMetadata &) const;
 
-    PyObject *read_numpy(const uint64_t *storage_id, ArrayMetadata *np_metas);
+    PyObject *read_numpy(const uint64_t *storage_id, ArrayMetadata &np_metas);
 
-    ArrayMetadata *make_metadata(PyObject *py_np_metas) const;
+    ArrayMetadata make_metadata(PyObject *py_np_metas) const;
 };
 
 

--- a/hecuba_core/src/py_interface/UnitParser.h
+++ b/hecuba_core/src/py_interface/UnitParser.h
@@ -35,6 +35,7 @@
 #define Py_FLOAT "f"
 #define Py_DOUBLE "d"
 #define Py_SHORT_INT "h"
+#define Py_UCHAR "b"
 
 class UnitParser {
 public:

--- a/hecuba_core/tests/runtests.cpp
+++ b/hecuba_core/tests/runtests.cpp
@@ -173,17 +173,16 @@ TEST(TestTBBQueue, Try_pop) {
 TEST(TestZorder, Zorder) {
     std::vector<uint32_t> ccs = {0, 0, 0, 2}; //row 3, column 2
     SpaceFillingCurve SP;
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    arr_metas->dims = {4, 4, 4, 4};
-    arr_metas->elem_size = sizeof(uint32_t);
-    arr_metas->partition_type = ZORDER_ALGORITHM;
+    ArrayMetadata arr_metas = ArrayMetadata();
+    arr_metas.dims = {4, 4, 4, 4};
+    arr_metas.elem_size = sizeof(uint32_t);
+    arr_metas.partition_type = ZORDER_ALGORITHM;
 
 
     ZorderCurveGenerator *partitioner = new ZorderCurveGenerator(arr_metas, nullptr);
     uint64_t result = partitioner->computeZorder(ccs);
     uint64_t expected_zorder = 128;
     EXPECT_EQ(expected_zorder, result);
-    delete (arr_metas);
     delete (partitioner);
 }
 
@@ -191,33 +190,31 @@ TEST(TestZorder, Zorder) {
 //Test to verify the Zorder Id and its inverse produce the same result
 TEST(TestZorder, ZorderInv) {
     std::vector<uint32_t> ccs = {23, 25, 40};
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    arr_metas->dims = {32, 40, 64};
-    arr_metas->elem_size = sizeof(uint32_t);
-    arr_metas->partition_type = ZORDER_ALGORITHM;
+    ArrayMetadata arr_metas = ArrayMetadata();
+    arr_metas.dims = {32, 40, 64};
+    arr_metas.elem_size = sizeof(uint32_t);
+    arr_metas.partition_type = ZORDER_ALGORITHM;
 
-    ZorderCurveGenerator *partitioner = new ZorderCurveGenerator();
+    ZorderCurveGenerator *partitioner = new ZorderCurveGenerator(arr_metas, nullptr);
     uint64_t result = partitioner->computeZorder(ccs);
     std::vector<uint32_t> inverse = partitioner->zorderInverse(result, ccs.size());
     EXPECT_TRUE(ccs == inverse);
-    delete (arr_metas);
     delete (partitioner);
 }
 
 //Verify that ZorderCurve::getIndexes returns the correct coordinates of the nth_element
 //inside an array of shape dims
 TEST(TestMakePartitions, Indexes) {
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    arr_metas->dims = {8, 8};
-    arr_metas->elem_size = sizeof(uint32_t);
-    arr_metas->partition_type = ZORDER_ALGORITHM;
+    ArrayMetadata arr_metas = ArrayMetadata();
+    arr_metas.dims = {8, 8};
+    arr_metas.elem_size = sizeof(uint32_t);
+    arr_metas.partition_type = ZORDER_ALGORITHM;
 
-    ZorderCurveGenerator *partitioner = new ZorderCurveGenerator();
+    ZorderCurveGenerator *partitioner = new ZorderCurveGenerator(arr_metas, nullptr);
     uint64_t nth_element = 43;
-    std::vector<uint32_t> indexes = partitioner->getIndexes(nth_element, arr_metas->dims);
+    std::vector<uint32_t> indexes = partitioner->getIndexes(nth_element, arr_metas.dims);
     std::vector<uint32_t> expected_coordinates = {5, 3};
     EXPECT_TRUE(indexes == expected_coordinates);
-    delete (arr_metas);
     delete (partitioner);
 }
 
@@ -226,17 +223,16 @@ TEST(TestMakePartitions, Indexes) {
 // produces the same result
 TEST(TestMakePartitions, Indexes2ways) {
     std::vector<uint32_t> ccs = {53, 28, 34};
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    arr_metas->dims = {32, 40, 64};
-    arr_metas->elem_size = sizeof(uint32_t);
-    arr_metas->partition_type = ZORDER_ALGORITHM;
+    ArrayMetadata arr_metas = ArrayMetadata();
+    arr_metas.dims = {32, 40, 64};
+    arr_metas.elem_size = sizeof(uint32_t);
+    arr_metas.partition_type = ZORDER_ALGORITHM;
 
-    ZorderCurveGenerator *partitioner = new ZorderCurveGenerator();
+    ZorderCurveGenerator *partitioner = new ZorderCurveGenerator(arr_metas, nullptr);
     uint64_t id = 1077;
     std::vector<uint32_t> indexes = partitioner->getIndexes(id, ccs);
     uint64_t computed_id = partitioner->getIdFromIndexes(ccs, indexes);
     EXPECT_EQ(computed_id, id);
-    delete (arr_metas);
     delete (partitioner);
 }
 
@@ -248,10 +244,10 @@ TEST(TestMakePartitions, 2DZorder) {
     uint32_t nrows = 463;
     uint32_t ncols = 53;
     std::vector<uint32_t> ccs = {nrows, ncols};
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    arr_metas->dims = ccs;
-    arr_metas->elem_size = sizeof(int32_t);
-    arr_metas->partition_type = ZORDER_ALGORITHM;
+    ArrayMetadata arr_metas = ArrayMetadata();
+    arr_metas.dims = ccs;
+    arr_metas.elem_size = sizeof(int32_t);
+    arr_metas.partition_type = ZORDER_ALGORITHM;
 
     int32_t *data = new int32_t[ncols * nrows];
     for (uint32_t row = 0; row < nrows; ++row) {
@@ -268,7 +264,7 @@ TEST(TestMakePartitions, 2DZorder) {
     while (!partitioner->isDone()) {
         Partition chunk = partitioner->getNextPartition();
         uint64_t *size = (uint64_t *) chunk.data;
-        uint64_t nelem = *size / arr_metas->elem_size;
+        uint64_t nelem = *size / arr_metas.elem_size;
         total_elem += nelem;
         int32_t *chunk_data = (int32_t *) ((char *) chunk.data + sizeof(uint64_t));
         for (uint64_t pos = 0; pos < nelem; ++pos) {
@@ -287,7 +283,6 @@ TEST(TestMakePartitions, 2DZorder) {
     EXPECT_EQ(*elements_found.begin(), 0);
     EXPECT_EQ(*elements_found.rbegin(), ncols * nrows - 1);
     delete[](data);
-    delete (arr_metas);
     delete (partitioner);
 }
 
@@ -301,10 +296,10 @@ TEST(TestMakePartitions, 2DZorderZeroes) {
     uint32_t nrows = 463;
     uint32_t ncols = 53;
     std::vector<uint32_t> ccs = {nrows, ncols};
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    arr_metas->dims = ccs;
-    arr_metas->elem_size = sizeof(double);
-    arr_metas->partition_type = ZORDER_ALGORITHM;
+    ArrayMetadata arr_metas = ArrayMetadata();
+    arr_metas.dims = ccs;
+    arr_metas.elem_size = sizeof(double);
+    arr_metas.partition_type = ZORDER_ALGORITHM;
 
     double *data = new double[ncols * nrows];
     for (uint32_t row = 0; row < nrows; ++row) {
@@ -322,7 +317,7 @@ TEST(TestMakePartitions, 2DZorderZeroes) {
     while (!partitioner->isDone()) {
         Partition chunk = partitioner->getNextPartition();
         uint64_t *size = (uint64_t *) chunk.data;
-        uint64_t nelem = *size / arr_metas->elem_size;
+        uint64_t nelem = *size / arr_metas.elem_size;
         total_elem += nelem;
         double *chunk_data = (double *) ((char *) chunk.data + sizeof(uint64_t));
         for (uint64_t pos = 0; pos < nelem; ++pos) {
@@ -338,19 +333,18 @@ TEST(TestMakePartitions, 2DZorderZeroes) {
 
     //void* array = partitioner.merge_partitions(arr_metas,chunks);
 
-    //std::cout << "FInal memcmp " << memcmp(array,data,ncols*nrows*arr_metas->elem_size) << std::endl;
+    //std::cout << "FInal memcmp " << memcmp(array,data,ncols*nrows*arr_metas.elem_size) << std::endl;
     delete[](data);
-    delete (arr_metas);
     delete (partitioner);
 }
 
 //Test to analyze the partitioning of a small 3D array
 TEST(TestMakePartitions, 3DZorder_Small) {
     std::vector<uint32_t> ccs = {17, 17, 17};
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    arr_metas->dims = ccs;
-    arr_metas->elem_size = sizeof(int32_t);
-    arr_metas->partition_type = ZORDER_ALGORITHM;
+    ArrayMetadata arr_metas = ArrayMetadata();
+    arr_metas.dims = ccs;
+    arr_metas.elem_size = sizeof(int32_t);
+    arr_metas.partition_type = ZORDER_ALGORITHM;
 
     uint64_t arr_size = 1;
     for (uint32_t size_dim:ccs) {
@@ -370,7 +364,7 @@ TEST(TestMakePartitions, 3DZorder_Small) {
     while (!partitioner->isDone()) {
         Partition chunk = partitioner->getNextPartition();
         uint64_t *size = (uint64_t *) chunk.data;
-        uint64_t nelem = *size / arr_metas->elem_size;
+        uint64_t nelem = *size / arr_metas.elem_size;
         total_elem += nelem;
         int32_t *chunk_data = (int32_t *) ((char *) chunk.data + sizeof(uint64_t));
         for (uint64_t pos = 0; pos < nelem; ++pos) {
@@ -394,17 +388,16 @@ TEST(TestMakePartitions, 3DZorder_Small) {
     EXPECT_EQ(total_elem, max_elem);
     EXPECT_EQ(elements_found.size(), max_elem);
     delete[](data);
-    delete (arr_metas);
     delete (partitioner);
 }
 
 //Test to analyze the partitioning of a medium 3D array, approx 72MB
 TEST(TestMakePartitions, 3DZorder_Medium) {
     std::vector<uint32_t> ccs = {250, 150, 500};
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    arr_metas->dims = ccs;
-    arr_metas->elem_size = sizeof(int32_t);
-    arr_metas->partition_type = ZORDER_ALGORITHM;
+    ArrayMetadata arr_metas = ArrayMetadata();
+    arr_metas.dims = ccs;
+    arr_metas.elem_size = sizeof(int32_t);
+    arr_metas.partition_type = ZORDER_ALGORITHM;
 
     uint64_t arr_size = 1;
     for (uint32_t size_dim:ccs) {
@@ -424,7 +417,7 @@ TEST(TestMakePartitions, 3DZorder_Medium) {
     while (!partitioner->isDone()) {
         Partition chunk = partitioner->getNextPartition();
         uint64_t *size = (uint64_t *) chunk.data;
-        uint64_t nelem = *size / arr_metas->elem_size;
+        uint64_t nelem = *size / arr_metas.elem_size;
         total_elem += nelem;
         int32_t *chunk_data = (int32_t *) ((char *) chunk.data + sizeof(uint64_t));
         for (uint64_t pos = 0; pos < nelem; ++pos) {
@@ -449,17 +442,16 @@ TEST(TestMakePartitions, 3DZorder_Medium) {
     }
     EXPECT_EQ(total_elem, max_elem);
     delete[](data);
-    delete (arr_metas);
 }
 
 
 //Test to analyze the partitioning of a big 3D array, approx 256MB
 TEST(TestMakePartitions, 3DZorder_Big) {
     std::vector<uint32_t> ccs = {512, 256, 512};
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    arr_metas->dims = ccs;
-    arr_metas->elem_size = sizeof(int32_t);
-    arr_metas->partition_type = ZORDER_ALGORITHM;
+    ArrayMetadata arr_metas = ArrayMetadata();
+    arr_metas.dims = ccs;
+    arr_metas.elem_size = sizeof(int32_t);
+    arr_metas.partition_type = ZORDER_ALGORITHM;
 
     uint64_t arr_size = 1;
     for (int32_t size_dim:ccs) {
@@ -479,7 +471,7 @@ TEST(TestMakePartitions, 3DZorder_Big) {
     while (!partitioner->isDone()) {
         Partition chunk = partitioner->getNextPartition();
         uint64_t *size = (uint64_t *) chunk.data;
-        uint64_t nelem = *size / arr_metas->elem_size;
+        uint64_t nelem = *size / arr_metas.elem_size;
         total_elem += nelem;
         int32_t *chunk_data = (int32_t *) ((char *) chunk.data + sizeof(uint64_t));
         for (uint64_t pos = 0; pos < nelem; ++pos) {
@@ -505,7 +497,6 @@ TEST(TestMakePartitions, 3DZorder_Big) {
     }
     EXPECT_EQ(total_elem, max_elem);
     delete[](data);
-    delete (arr_metas);
 
 }
 
@@ -513,11 +504,11 @@ TEST(TestMakePartitions, 3DZorder_Big) {
 TEST(TestMakePartitions, NDZorder) {
     uint32_t max_dims = 6;
     std::vector<uint32_t> ccs = {17};
-    ArrayMetadata *arr_metas = new ArrayMetadata();
+    ArrayMetadata arr_metas = ArrayMetadata();
     while (ccs.size() <= max_dims) {
-        arr_metas->dims = ccs;
-        arr_metas->elem_size = sizeof(int32_t);
-        arr_metas->partition_type = ZORDER_ALGORITHM;
+        arr_metas.dims = ccs;
+        arr_metas.elem_size = sizeof(int32_t);
+        arr_metas.partition_type = ZORDER_ALGORITHM;
 
         uint64_t arr_size = 1;
         for (int32_t size_dim:ccs) {
@@ -537,7 +528,7 @@ TEST(TestMakePartitions, NDZorder) {
         while (!partitioner->isDone()) {
             Partition chunk = partitioner->getNextPartition();
             uint64_t *size = (uint64_t *) chunk.data;
-            uint64_t nelem = *size / arr_metas->elem_size;
+            uint64_t nelem = *size / arr_metas.elem_size;
             total_elem += nelem;
             int32_t *chunk_data = (int32_t *) ((char *) chunk.data + sizeof(uint64_t));
             for (uint64_t pos = 0; pos < nelem; ++pos) {
@@ -566,9 +557,6 @@ TEST(TestMakePartitions, NDZorder) {
 
         ccs.push_back(17);
     }
-
-    delete (arr_metas);
-
 }
 
 //Test partitioning 2Dimensions with Doubles
@@ -576,10 +564,10 @@ TEST(TestMakePartitions, 2DZorder128Double) {
     uint32_t ncols = 1000;
     uint32_t nrows = 1000;
     std::vector<uint32_t> ccs = {nrows, ncols}; //4D 128 elements
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    arr_metas->dims = ccs;
-    arr_metas->elem_size = sizeof(double);
-    arr_metas->partition_type = ZORDER_ALGORITHM;
+    ArrayMetadata arr_metas = ArrayMetadata();
+    arr_metas.dims = ccs;
+    arr_metas.elem_size = sizeof(double);
+    arr_metas.partition_type = ZORDER_ALGORITHM;
 
 
     uint64_t arr_size = 1;
@@ -601,7 +589,7 @@ TEST(TestMakePartitions, 2DZorder128Double) {
     while (!partitioner->isDone()) {
         Partition chunk = partitioner->getNextPartition();
         uint64_t *size = (uint64_t *) chunk.data;
-        uint64_t nelem = *size / arr_metas->elem_size;
+        uint64_t nelem = *size / arr_metas.elem_size;
         total_elem += nelem;
         double *chunk_data = (double *) ((char *) chunk.data + sizeof(uint64_t));
         for (uint64_t pos = 0; pos < nelem; ++pos) {
@@ -620,7 +608,6 @@ TEST(TestMakePartitions, 2DZorder128Double) {
     EXPECT_EQ(*elements_found.begin(), 0);
     EXPECT_EQ(*elements_found.rbegin(), ncols * nrows - 1);
     delete[](data);
-    delete (arr_metas);
     delete (partitioner);
 }
 
@@ -634,10 +621,10 @@ TEST(TestMakePartitions, 2DZorderByRange) {
     for (uint32_t ncols = 1; ncols < maxcols; ++ncols) {
         for (uint32_t nrows = 1; nrows < maxrows; ++nrows) {
             std::vector<uint32_t> ccs = {nrows, ncols}; //4D 128 elements
-            ArrayMetadata *arr_metas = new ArrayMetadata();
-            arr_metas->dims = ccs;
-            arr_metas->elem_size = sizeof(double);
-            arr_metas->partition_type = ZORDER_ALGORITHM;
+            ArrayMetadata arr_metas = ArrayMetadata();
+            arr_metas.dims = ccs;
+            arr_metas.elem_size = sizeof(double);
+            arr_metas.partition_type = ZORDER_ALGORITHM;
 
             uint64_t arr_size = 1;
             for (int32_t size_dim:ccs) {
@@ -658,7 +645,7 @@ TEST(TestMakePartitions, 2DZorderByRange) {
             while (!partitioner->isDone()) {
                 Partition chunk = partitioner->getNextPartition();
                 uint64_t *size = (uint64_t *) chunk.data;
-                uint64_t nelem = *size / arr_metas->elem_size;
+                uint64_t nelem = *size / arr_metas.elem_size;
                 total_elem += nelem;
                 double *chunk_data = (double *) ((char *) chunk.data + sizeof(uint64_t));
                 for (uint64_t pos = 0; pos < nelem; ++pos) {
@@ -685,7 +672,6 @@ TEST(TestMakePartitions, 2DZorderByRange) {
             EXPECT_EQ(total_elem, ncols * nrows);
             EXPECT_EQ(elements_found.size(), ncols * nrows);
             delete[](data);
-            delete (arr_metas);
         }
     }
 }
@@ -698,10 +684,10 @@ TEST(TestMakePartitions, 2DNopart) {
     uint32_t ncols = 1104;
     int32_t arr_size = ncols * nrows;
     std::vector<uint32_t> ccs = {ncols, nrows};
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    arr_metas->dims = ccs;
-    arr_metas->elem_size = sizeof(int32_t);
-    arr_metas->partition_type = NO_PARTITIONS;
+    ArrayMetadata arr_metas = ArrayMetadata();
+    arr_metas.dims = ccs;
+    arr_metas.elem_size = sizeof(int32_t);
+    arr_metas.partition_type = NO_PARTITIONS;
 
     int32_t *data = new int32_t[arr_size];
     for (uint32_t col = 0; col < ncols; ++col) {
@@ -714,13 +700,12 @@ TEST(TestMakePartitions, 2DNopart) {
     Partition part = partitioner->getNextPartition();
     EXPECT_TRUE(partitioner->isDone());
     uint64_t *chunk_size = (uint64_t *) part.data;
-    EXPECT_EQ(*chunk_size, arr_size * arr_metas->elem_size);
+    EXPECT_EQ(*chunk_size, arr_size * arr_metas.elem_size);
     char *partition_data = ((char *) part.data) + sizeof(uint64_t);
     int32_t equal = memcmp(partition_data, data, arr_size * sizeof(int32_t));
     EXPECT_TRUE(equal == 0);
     EXPECT_FALSE(data == (int32_t *) partition_data);
     delete[](data);
-    delete (arr_metas);
     delete (partitioner);
 }
 
@@ -731,10 +716,10 @@ TEST(TestMakePartitions, 2DNopart) {
 // into a single array and make sure both processes performed correctly
 TEST(TestMakePartitions, 3DZorderAndReverse) {
     std::vector<uint32_t> ccs = {45, 17, 32};
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    arr_metas->dims = ccs;
-    arr_metas->elem_size = sizeof(int32_t);
-    arr_metas->partition_type = ZORDER_ALGORITHM;
+    ArrayMetadata arr_metas = ArrayMetadata();
+    arr_metas.dims = ccs;
+    arr_metas.elem_size = sizeof(int32_t);
+    arr_metas.partition_type = ZORDER_ALGORITHM;
 
     uint64_t arr_size = 1;
     for (int32_t size_dim:ccs) {
@@ -752,7 +737,7 @@ TEST(TestMakePartitions, 3DZorderAndReverse) {
     while (!partitioner->isDone()) {
         Partition chunk = partitioner->getNextPartition();
         uint64_t *size = (uint64_t *) chunk.data;
-        uint64_t nelem = *size / arr_metas->elem_size;
+        uint64_t nelem = *size / arr_metas.elem_size;
         total_elem += nelem;
         int32_t *chunk_data = (int32_t *) ((char *) chunk.data + sizeof(uint64_t));
         for (uint64_t pos = 0; pos < nelem; ++pos) {
@@ -788,7 +773,6 @@ TEST(TestMakePartitions, 3DZorderAndReverse) {
     EXPECT_TRUE(equal == 0);
     free(array);
     delete[](data);
-    delete (arr_metas);
     for (Partition chunk:chunks) {
         free(chunk.data);
     }
@@ -802,10 +786,10 @@ TEST(TestMakePartitions, 3DZorderAndReverse) {
 // into a single array and make sure both processes performed correctly
 TEST(TestMakePartitions, 4DZorderAndReverse) {
     std::vector<uint32_t> ccs = {100, 20, 150, 30};
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    arr_metas->dims = ccs;
-    arr_metas->elem_size = sizeof(int32_t);
-    arr_metas->partition_type = ZORDER_ALGORITHM;
+    ArrayMetadata arr_metas = ArrayMetadata();
+    arr_metas.dims = ccs;
+    arr_metas.elem_size = sizeof(int32_t);
+    arr_metas.partition_type = ZORDER_ALGORITHM;
 
     uint64_t arr_size = 1;
     for (int32_t size_dim:ccs) {
@@ -823,7 +807,7 @@ TEST(TestMakePartitions, 4DZorderAndReverse) {
     while (!partitioner->isDone()) {
         Partition chunk = partitioner->getNextPartition();
         uint64_t *size = (uint64_t *) chunk.data;
-        uint64_t nelem = *size / arr_metas->elem_size;
+        uint64_t nelem = *size / arr_metas.elem_size;
         total_elem += nelem;
         int32_t *chunk_data = (int32_t *) ((char *) chunk.data + sizeof(uint64_t));
         for (uint64_t pos = 0; pos < nelem; ++pos) {
@@ -858,7 +842,6 @@ TEST(TestMakePartitions, 4DZorderAndReverse) {
     EXPECT_TRUE(equal == 0);
     free(array);
     delete[](data);
-    delete (arr_metas);
     for (Partition chunk:chunks) {
         free(chunk.data);
     }
@@ -870,10 +853,10 @@ TEST(TestMakePartitions, ReadBlockOnlyOnce) {
     uint32_t nrows = 463;
     uint32_t ncols = 53;
     std::vector<uint32_t> ccs = {nrows, ncols};
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    arr_metas->dims = ccs;
-    arr_metas->elem_size = sizeof(int32_t);
-    arr_metas->partition_type = ZORDER_ALGORITHM;
+    ArrayMetadata arr_metas = ArrayMetadata();
+    arr_metas.dims = ccs;
+    arr_metas.elem_size = sizeof(int32_t);
+    arr_metas.partition_type = ZORDER_ALGORITHM;
 
     int32_t *data = new int32_t[ncols * nrows];
     for (uint32_t row = 0; row < nrows; ++row) {
@@ -892,7 +875,7 @@ TEST(TestMakePartitions, ReadBlockOnlyOnce) {
     while (!partitioner->isDone()) {
         Partition chunk = partitioner->getNextPartition();
         uint64_t *size = (uint64_t *) chunk.data;
-        uint64_t nelem = *size / arr_metas->elem_size;
+        uint64_t nelem = *size / arr_metas.elem_size;
         total_elem += nelem;
         int32_t *chunk_data = (int32_t *) ((char *) chunk.data + sizeof(uint64_t));
         for (uint64_t pos = 0; pos < nelem; ++pos) {
@@ -941,7 +924,6 @@ TEST(TestMakePartitions, ReadBlockOnlyOnce) {
         ASSERT_TRUE(it.second);
     }
 
-    delete (arr_metas);
     delete (partitioner);
 }
 

--- a/hecuba_py/hecuba/__init__.py
+++ b/hecuba_py/hecuba/__init__.py
@@ -212,7 +212,7 @@ class Config:
                 to_point frozen<list<double>>,
                 precision float);
                 """,
-                """CREATE TYPE IF NOT EXISTS hecuba.np_meta (flags int, elem_size int, partition_type int,
+                """CREATE TYPE IF NOT EXISTS hecuba.np_meta (flags int, elem_size int, partition_type tinyint,
                 dims list<int>, strides list<int>, typekind text, byteorder text)""",
                 """CREATE TABLE IF NOT EXISTS hecuba
                 .istorage (storage_id uuid, 
@@ -234,9 +234,11 @@ class Config:
                     log.error("Error executing query %s" % query)
                     raise e
 
-        from hfetch import connectCassandra
+        from hfetch import connectCassandra, HArrayMetadata
         # connecting c++ bindings
         connectCassandra(singleton.contact_names, singleton.nodePort)
+
+        singleton.cluster.register_user_type('hecuba', 'np_meta', HArrayMetadata)
 
 
 global config

--- a/hecuba_py/tests/withcassandra/hfetch_tests.py
+++ b/hecuba_py/tests/withcassandra/hfetch_tests.py
@@ -1,6 +1,8 @@
 import unittest
+import numpy as np
 
 from hecuba import config, StorageDict
+from hfetch import HArrayMetadata
 
 
 class ConcurrentDict(StorageDict):
@@ -30,3 +32,43 @@ class HfetchTests(unittest.TestCase):
         config.timestamped_writes = previous_cfg
 
         self.assertEqual(retrieved, last_value - 1)
+
+    def test_harray_metadata_init(self):
+        base = np.arange(7 * 8 * 9 * 10).reshape((7, 8, 9, 10))
+
+        args = (list(base.shape), list(base.strides), base.dtype.kind, base.dtype.byteorder,
+                base.itemsize, base.flags.num, 0)
+
+        obj = HArrayMetadata(*args)
+
+        with self.assertRaises(TypeError):
+            obj = HArrayMetadata()
+
+        with self.assertRaises(TypeError):
+            obj = HArrayMetadata(args[1:])
+
+    def test_harray_metadata_refs(self):
+        base = np.arange(10)
+        args = (list(base.shape), list(base.strides), base.dtype.kind, base.dtype.byteorder,
+                base.itemsize, base.flags.num, 0)
+
+        obj = HArrayMetadata(*args)
+        import gc
+        gc.collect()
+        import sys
+        # The test has the first ref, the method getrefcount has the second reference
+        self.assertEqual(sys.getrefcount(obj), 2)
+
+    def test_register(self):
+        from hfetch import HArrayMetadata
+        # connecting c++ bindings
+        from hecuba import config
+        config.session.execute("DROP KEYSPACE IF EXISTS test_np_meta;")
+
+        config.session.execute("CREATE KEYSPACE IF NOT EXISTS test_np_meta "
+                               "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};")
+
+        config.session.execute("""CREATE TYPE IF NOT EXISTS test_np_meta.np_meta (flags int, elem_size int, 
+        partition_type tinyint, dims list<int>, strides list<int>, typekind text, byteorder text)""")
+
+        config.cluster.register_user_type('test_np_meta', 'np_meta', HArrayMetadata)

--- a/hecuba_py/tests/withcassandra/storagenumpy_tests.py
+++ b/hecuba_py/tests/withcassandra/storagenumpy_tests.py
@@ -86,30 +86,6 @@ class StorageNumpyTest(unittest.TestCase):
         basic_init = StorageNumpy(base_array)
         new_from_template = basic_init[:32]
 
-    def test_explicit_construct(self):
-        # From an explicit constructor - e.g. InfoArray():
-        #    obj is None
-        #    (we're in the middle of the InfoArray.__new__
-        #    constructor, and self.info will be set when we return to
-        #    InfoArray.__new__)
-
-        basic_init = StorageNumpy()
-
-    def test_view_cast(self):
-        # From view casting - e.g arr.view(InfoArray):
-        #    obj is arr
-        #    (type(obj) can be InfoArray)
-
-        base_array = np.arange(4096).reshape((64, 64))
-        view_cast = base_array.view(StorageNumpy)
-
-    def test_new_from_template(self):
-        # From new-from-template - e.g infoarr[:3]
-        #    type(obj) is InfoArray
-        base_array = np.arange(4096).reshape((64, 64))
-        basic_init = StorageNumpy(base_array)
-        new_from_template = basic_init[:32]
-
     def test_read_all(self):
         nelem = 2 ** 21
         elem_dim = 2 ** 7
@@ -125,8 +101,7 @@ class StorageNumpyTest(unittest.TestCase):
         chunk = casted[slice(None, None, None)]
         self.assertTrue(np.allclose(chunk.view(np.ndarray), test_numpy))
 
-
-    def test_mulitply(self):
+    def test_multiply(self):
         nelem = 2 ** 10
         elem_dim = 2 ** 5
 


### PR DESCRIPTION
Same metadata definition for arrays in C++ and Python.
In this way, we ensure C/C++ array's metadata follows the same format as Python's
