### PR TITLE
[To be reviewed] Add BSC agreed storage api syntax

### DIFF
--- a/hecuba_py/hecuba/IStorage.py
+++ b/hecuba_py/hecuba/IStorage.py
@@ -34,6 +34,10 @@ class IStorage(object):
         self._tokens = kwargs.pop("tokens", None)
         self._is_persistent = False
 
+    @classmethod
+    def get_by_alias(cls, alias=""):
+        return cls(name=alias)
+
     def __eq__(self, other):
         """
         Method to compare a IStorage object with another one.

--- a/hecuba_py/tests/withcassandra/storage_api_tests.py
+++ b/hecuba_py/tests/withcassandra/storage_api_tests.py
@@ -2,12 +2,19 @@ import unittest
 
 from storage.api import getByID
 from ..app.words import Words
-from hecuba import config, StorageDict
+from storage.api import StorageDict, StorageObject, StorageNumpy
 
 
 class ApiTestSDict(StorageDict):
     '''
     @TypeSpec dict<<key:int>, value:double>
+    '''
+
+
+class ApiTestSObject(StorageObject):
+    '''
+    @ClassField attr int
+    @ClassField attr2 str
     '''
 
 
@@ -47,3 +54,18 @@ class StorageApi_Tests(unittest.TestCase):
         b = Words('testspace.tt')
         new_block = getByID(b.storage_id)
         self.assertEqual(b, new_block)
+
+    def test_get_by_alias(self):
+        attr = 123
+        attr2 = "textattribute"
+        obj = ApiTestSObject('test.api_by_alias')
+        obj.attr = attr
+        obj.attr2 = attr2
+        del obj
+        rebuild = ApiTestSObject.get_by_alias('test.api_by_alias')
+        self.assertEqual(rebuild.attr, attr)
+        self.assertEqual(rebuild.attr2, attr2)
+
+        obj2 = ApiTestSDict('test.api_by_alias2')
+        rebuild = ApiTestSDict.get_by_alias('test.api_by_alias2')
+        self.assertEqual(obj2, rebuild)

--- a/storageAPI/storage/api.py
+++ b/storageAPI/storage/api.py
@@ -1,4 +1,6 @@
 import uuid
+from hecuba import StorageNumpy, StorageDict
+from hecuba import StorageObj as StorageObject
 
 
 def init(config_file_path=None):

--- a/storageAPI/storage/api.py
+++ b/storageAPI/storage/api.py
@@ -1,4 +1,3 @@
-import uuid
 from hecuba import StorageNumpy, StorageDict
 from hecuba import StorageObj as StorageObject
 
@@ -95,6 +94,7 @@ def getByID(objid):
     from hecuba import log
     from hecuba.IStorage import build_remotely
     from hecuba import config
+    import uuid
 
     query = "SELECT * FROM hecuba.istorage WHERE storage_id = %s"
 


### PR DESCRIPTION
- Allow to import StorageDict, StorageObj and so on from the storage.api: `from storage.api import StorageObject`
- Add `get_by_alias` classmethod to Storage objects