### PR TITLE
[To be reviewed] Flush before split or creating iterators

### DIFF
--- a/hecuba_py/hecuba/IStorage.py
+++ b/hecuba_py/hecuba/IStorage.py
@@ -93,6 +93,10 @@ class IStorage(object):
         except AttributeError:
             return ''
 
+    def _flush_to_storage(self):
+        if not self._is_persistent:
+            raise RuntimeError("Can't send the data to storage if the object is not persistent")
+
     def getID(self):
         """
         Method to retrieve the storage id as string. Used by PyCOMPSs solely.
@@ -111,6 +115,8 @@ class IStorage(object):
             tokens = self._build_args.tokens
         except AttributeError as ex:
             raise RuntimeError("Object {} does not have tokens".format(self._get_name()))
+
+        self._flush_to_storage()
 
         for token_split in tokens_partitions(self._ksp, self._table, tokens):
             storage_id = uuid.uuid4()

--- a/hecuba_py/hecuba/storageobj.py
+++ b/hecuba_py/hecuba/storageobj.py
@@ -123,6 +123,14 @@ class StorageObj(IStorage):
             log.error("Unable to execute %s", query_simple)
             raise ir
 
+    def _flush_to_storage(self):
+        super()._flush_to_storage()
+
+        for attr_name in self._persistent_attrs:
+            attr = getattr(super(), attr_name, None)
+            if isinstance(attr, IStorage):
+                attr._flush_to_storage()
+
     def make_persistent(self, name):
         """
             Once a StorageObj has been created, it can be made persistent. This function retrieves the information about
@@ -300,7 +308,7 @@ class StorageObj(IStorage):
                 if not value.storage_id:
                     attr_name = attribute.lower()
                     my_name = self._get_name()
-                    trailing_name = my_name[my_name.rfind('.')+1:]
+                    trailing_name = my_name[my_name.rfind('.') + 1:]
 
                     count = count_name_collision(self._ksp, trailing_name, attr_name)
                     attr_name = self._ksp + '.' + trailing_name + '_' + attr_name

--- a/hecuba_py/tests/withcassandra/storagedict_split_tests.py
+++ b/hecuba_py/tests/withcassandra/storagedict_split_tests.py
@@ -62,15 +62,6 @@ class StorageDictSplitTestbase(unittest.TestCase):
         for i in range(num_inserts):
             pd[i] = 'ciao' + str(i)
             what_should_be.add(i)
-        del pd
-        import gc
-        gc.collect()
-        count, = config.session.execute('SELECT count(*) FROM my_app.tab30')[0]
-        self.assertEqual(count, num_inserts)
-
-        pd = StorageDict(tablename,
-                         [('position', 'int')],
-                         [('value', 'text')])
 
         count = 0
         res = set()
@@ -80,6 +71,9 @@ class StorageDictSplitTestbase(unittest.TestCase):
                 count += 1
         self.assertEqual(count, num_inserts)
         self.assertEqual(what_should_be, res)
+
+        count, = config.session.execute('SELECT count(*) FROM my_app.tab30')[0]
+        self.assertEqual(count, num_inserts)
 
     def test_remote_build_iterkeys_split(self):
         config.session.execute(
@@ -93,16 +87,10 @@ class StorageDictSplitTestbase(unittest.TestCase):
         for i in range(num_inserts):
             pd[i] = 'ciao' + str(i)
             what_should_be.add(i)
-        del pd
-        import gc
-        gc.collect()
-        count, = config.session.execute('SELECT count(*) FROM my_app.tab_b0')[0]
-        self.assertEqual(count, num_inserts)
 
         pd = StorageDict(tablename,
                          [('position', 'int')],
                          [('value', 'text')])
-
         count = 0
         res = set()
         for partition in pd.split():
@@ -114,6 +102,9 @@ class StorageDictSplitTestbase(unittest.TestCase):
                 count += 1
         self.assertEqual(count, num_inserts)
         self.assertEqual(what_should_be, res)
+
+        count, = config.session.execute('SELECT count(*) FROM my_app.tab_b0')[0]
+        self.assertEqual(count, num_inserts)
 
     def test_composed_iteritems(self):
         config.session.execute(
@@ -128,14 +119,6 @@ class StorageDictSplitTestbase(unittest.TestCase):
             pd[i, i + 100] = ['ciao' + str(i), i * 0.1, i * 0.2, i * 0.3]
             what_should_be[i, i + 100] = ('ciao' + str(i), i * 0.1, i * 0.2, i * 0.3)
 
-        del pd
-        import gc
-        gc.collect()
-        count, = config.session.execute('SELECT count(*) FROM my_app.tab_b1')[0]
-        self.assertEqual(count, num_inserts)
-        pd = StorageDict(tablename,
-                         [('pid', 'int'), ('time', 'int')],
-                         [('value', 'text'), ('x', 'float'), ('y', 'float'), ('z', 'float')])
         count = 0
         res = {}
         for partition in pd.split():
@@ -143,6 +126,10 @@ class StorageDictSplitTestbase(unittest.TestCase):
                 res[key] = val
                 count += 1
         self.assertEqual(count, num_inserts)
+
+        count, = config.session.execute('SELECT count(*) FROM my_app.tab_b1')[0]
+        self.assertEqual(count, num_inserts)
+
         delta = 0.0001
         for i in range(num_inserts):
             a = what_should_be[i, i + 100]

--- a/hecuba_py/tests/withcassandra/storagedict_tests.py
+++ b/hecuba_py/tests/withcassandra/storagedict_tests.py
@@ -239,9 +239,6 @@ class StorageDictTest(unittest.TestCase):
 
         nopars.make_persistent('test.test_dict_len')
         self.assertEqual(len(nopars.words), ninserts)
-        del nopars
-        import gc
-        gc.collect()
 
     def test_len_persistent(self):
         config.session.execute("DROP TABLE IF EXISTS test.test_dict_len")
@@ -256,10 +253,6 @@ class StorageDictTest(unittest.TestCase):
             nopars.words[i] = 'ciao' + str(i)
 
         self.assertEqual(len(nopars.words), ninserts)
-
-        del nopars
-        import gc
-        gc.collect()
 
         rebuild = Words('test.test_dict_len')
         self.assertEqual(len(rebuild.words), ninserts)
@@ -1214,9 +1207,6 @@ class StorageDictTest(unittest.TestCase):
             what_should_be[keys] = [cols]
             d[keys] = [cols]
 
-        del d
-        import gc
-        gc.collect()
         d = DictWithDates("my_app.dictwithdates")
 
         self.assertEqual(len(list(d.keys())), len(what_should_be.keys()))
@@ -1238,9 +1228,6 @@ class StorageDictTest(unittest.TestCase):
             what_should_be[keys] = [cols]
             d[keys] = [cols]
 
-        del d
-        import gc
-        gc.collect()
         d = DictWithTimes("my_app.dictwithtimes")
 
         self.assertEqual(len(list(d.keys())), len(what_should_be.keys()))
@@ -1261,10 +1248,6 @@ class StorageDictTest(unittest.TestCase):
             cols = self.gen_random_datetime()
             what_should_be[keys] = [cols]
             d[keys] = [cols]
-
-        del d
-        import gc
-        gc.collect()
 
         d = DictWithDateTimes("my_app.dictwithdatetimes")
         self.assertEqual(len(list(d.keys())), len(what_should_be.keys()))


### PR DESCRIPTION
These solves two types of data coherence issues, currently solved by `del` and `gc.collect()`

1- When doing a split of a dataset, the chunks created used to contain less data. Said data was still in the write path of the original object

2- Creating iterators on dicts, did not include data that was still in the write path.