### PR TITLE
[To be reviewed] Add reservation option to constraints

### DIFF
--- a/cassandra4slurm/launcher.sh
+++ b/cassandra4slurm/launcher.sh
@@ -268,6 +268,10 @@ case $i in
     QUEUE="--qos=""${i#*=}"
     shift
     ;;
+    -res=*|--reservation=*)
+    CONSTRAINTS=$CONSTRAINTS" --reservation=""${i#*=}"
+    shift
+    ;;
     -con=*|--constraint=*)
     CONSTRAINTS=$CONSTRAINTS" --constraint=""${i#*=}"
     shift


### PR DESCRIPTION
Now we can do:

```bash
c4s RUN -f -t=00:10:00 --appl="..."  -nT=1 --qos=debug -res=MY_RESERVATION
```