### PR TITLE
[WIP] Add meta manager

### DIFF
--- a/hecuba_core/CMakeLists.txt
+++ b/hecuba_core/CMakeLists.txt
@@ -259,6 +259,13 @@ if (DEFINED ENV{GTEST_ROOT})
             add_dependencies(cache_imp_test hfetch)
             add_test(test cache_imp_test)
 
+            # Meta manager tests
+            add_executable(meta_manager_test tests/meta_manager_tests.cpp)
+            set_target_properties(meta_manager_test
+                    PROPERTIES BUILD_WITH_INSTALL_RPATH 0)
+            target_link_libraries(meta_manager_test ${ALL_LIBS} ${GTEST_BOTH_LIBRARIES} hfetch ${PT})
+            add_dependencies(meta_manager_test hfetch)
+            add_test(test meta_manager_test)
 
             # Mixed Python Tests
             find_package(Python3 COMPONENTS Interpreter Development)

--- a/hecuba_core/src/MetaManager.cpp
+++ b/hecuba_core/src/MetaManager.cpp
@@ -3,6 +3,8 @@
 
 MetaManager::MetaManager(const TableMetadata *table_meta, CassSession *session,
                          std::map<std::string, std::string> &config) {
+
+
     this->writer = new Writer(table_meta, session, config);
 }
 
@@ -31,7 +33,7 @@ void MetaManager::register_obj(const uint64_t *storage_id, const std::string &na
     char *c_name = (char *) std::malloc(name.length() + 1);
     std::memcpy(c_name, name.c_str(), name.length() + 1);
 
-    void *values = std::malloc(sizeof(char *)); //+sizeof(numpy_meta));
+    void *values = std::malloc(sizeof(char *) + sizeof(numpy_meta));
     std::memcpy(values, &c_name, sizeof(char *));
 
     //std::memcpy(values+sizeof(c_name), numpy_meta, sizeof(numpy_meta));

--- a/hecuba_core/src/MetaManager.cpp
+++ b/hecuba_core/src/MetaManager.cpp
@@ -1,0 +1,39 @@
+#include "MetaManager.h"
+
+
+MetaManager::MetaManager(const TableMetadata *table_meta, CassSession *session,
+                         std::map<std::string, std::string> &config) {
+    this->writer = new Writer(table_meta, session, config);
+}
+
+MetaManager::~MetaManager() {
+    delete (this->writer);
+}
+
+void MetaManager::create_data_model(const std::string &create_table_query) const {
+    /* TODO
+    Distributed agreement on table creation:
+    1) r = insert if not exists on agreement table
+    2) if !r -> create table
+    3) else wait*/
+
+    throw ModuleException("Not implemented yet");
+}
+
+
+void MetaManager::register_obj(const uint64_t *storage_id, const std::string &name,
+        const ArrayMetadata *numpy_meta) const {
+
+    void *keys = std::malloc(sizeof(storage_id));
+    std::memcpy(keys, &storage_id, sizeof(uint64_t *));
+
+    //char *c_name = new char[name.length() + 1];
+    char *c_name = (char *) std::malloc(name.length() + 1);
+    std::memcpy(c_name, name.c_str(), name.length() + 1);
+
+    void *values = std::malloc(sizeof(char *)); //+sizeof(numpy_meta));
+    std::memcpy(values, &c_name, sizeof(char *));
+
+    //std::memcpy(values+sizeof(c_name), numpy_meta, sizeof(numpy_meta));
+    this->writer->write_to_cassandra(keys, values);
+}

--- a/hecuba_core/src/MetaManager.h
+++ b/hecuba_core/src/MetaManager.h
@@ -1,0 +1,28 @@
+#ifndef HECUBA_CORE_METAMANAGER_H
+#define HECUBA_CORE_METAMANAGER_H
+
+#include "string"
+#include "Writer.h"
+#include "SpaceFillingCurve.h"
+#include "ModuleException.h"
+
+class MetaManager {
+
+public:
+
+    MetaManager(const TableMetadata *table_meta, CassSession *session,
+                std::map<std::string, std::string> &config);
+
+    ~MetaManager();
+
+    void create_data_model(const std::string &create_table_query) const;
+
+
+    void register_obj(const uint64_t storage_id[], const std::string &name, const ArrayMetadata *numpy_meta) const;
+
+private:
+    Writer *writer;
+};
+
+
+#endif //HECUBA_CORE_METAMANAGER_H

--- a/hecuba_core/src/StorageInterface.cpp
+++ b/hecuba_core/src/StorageInterface.cpp
@@ -112,6 +112,15 @@ ArrayDataStore *StorageInterface::make_array_store(const char *table, const char
 }
 
 
+MetaManager *StorageInterface::make_meta_manager(const char *table, const char *keyspace,
+                                                 std::vector<config_map> &keys_names,
+                                                 std::vector<config_map> &columns_names,
+                                                 config_map &config) {
+    if (!session) throw ModuleException("StorageInterface not connected to any node");
+    TableMetadata *table_meta = new TableMetadata(table, keyspace, keys_names, columns_names, session);
+    return new MetaManager(table_meta, session, config);
+}
+
 /*** ITERATOR METHODS AND SETUP ***/
 
 /***

--- a/hecuba_core/src/StorageInterface.h
+++ b/hecuba_core/src/StorageInterface.h
@@ -14,8 +14,8 @@
 #include "Prefetch.h"
 #include "Writer.h"
 #include "CacheTable.h"
-
 #include "ArrayDataStore.h"
+#include "MetaManager.h"
 
 typedef std::map<std::string, std::string> config_map;
 
@@ -59,6 +59,13 @@ public:
     Prefetch *get_iterator(const TableMetadata *table_meta,
                            const std::vector<std::pair<int64_t, int64_t>> &tokens,
                            config_map &config);
+
+
+    MetaManager *make_meta_manager(const char *table, const char *keyspace,
+                                   std::vector<config_map> &keys_names,
+                                   std::vector<config_map> &columns_names,
+                                   config_map &config);
+
 
     inline CassSession *get_session() {
         return this->session;

--- a/hecuba_core/src/TableMetadata.h
+++ b/hecuba_core/src/TableMetadata.h
@@ -22,15 +22,18 @@ struct ColumnMeta {
     ColumnMeta(const ColumnMeta &CM) {
         this->info = CM.info;
         this->type = CM.type;
+        this->dtype = CM.dtype;
         this->position = CM.position;
         this->size = CM.size;
         this->col_type = CM.col_type;
         this->pointer = CM.pointer;
     }
 
-    ColumnMeta(std::map<std::string, std::string> &info, CassValueType cv_type, uint16_t offset, uint16_t bsize) {
+    ColumnMeta(std::map<std::string, std::string> &info, CassValueType cv_type, CassDataType *cd_type, uint16_t offset,
+               uint16_t bsize) {
         this->info = info;
         this->type = cv_type;
+        this->dtype = cd_type;
         this->position = offset;
         this->size = bsize;
         this->col_type = CASS_COLUMN_TYPE_REGULAR;
@@ -38,6 +41,7 @@ struct ColumnMeta {
 
     uint16_t position, size;
     CassValueType type;
+    const CassDataType *dtype;
     CassColumnType col_type;
     std::map<std::string, std::string> info;
     std::shared_ptr<std::vector<ColumnMeta> > pointer;

--- a/hecuba_core/src/TupleRow.cpp
+++ b/hecuba_core/src/TupleRow.cpp
@@ -13,12 +13,18 @@ TupleRow::TupleRow(std::shared_ptr<const std::vector<ColumnMeta>> metas,
                                                             case CASS_VALUE_TYPE_BLOB:
                                                             case CASS_VALUE_TYPE_TEXT:
                                                             case CASS_VALUE_TYPE_VARCHAR:
-                                                            case CASS_VALUE_TYPE_UUID:
                                                             case CASS_VALUE_TYPE_ASCII: {
                                                                 int64_t *addr = (int64_t *) ((char *) holder->data +
                                                                                              metas->at(i).position);
                                                                 char *d = reinterpret_cast<char *>(*addr);
                                                                 free(d);
+                                                                break;
+                                                            }
+                                                            case CASS_VALUE_TYPE_UUID: {
+                                                                int64_t *addr = (int64_t *) ((char *) holder->data +
+                                                                                             metas->at(i).position);
+                                                                uint64_t *uuid = reinterpret_cast<uint64_t *>(*addr);
+                                                                delete[] uuid;
                                                                 break;
                                                             }
                                                             case CASS_VALUE_TYPE_TUPLE: {

--- a/hecuba_core/src/TupleRowFactory.cpp
+++ b/hecuba_core/src/TupleRowFactory.cpp
@@ -539,13 +539,28 @@ TupleRowFactory::bind(CassStatement *statement, const TupleRow *row, u_int16_t o
                                metadata->at(i).info.begin()->second);
                     break;
                 }
+                case CASS_VALUE_TYPE_UDT: {
+                    int64_t *addr = (int64_t *) element_i;
+                    ArrayMetadata *np_metas = reinterpret_cast<ArrayMetadata *>(*addr);
+                    CassUserType* cass_np_meta = cass_user_type_new_from_data_type(metadata->at(i).dtype);
+                    std::string field_name = "block_id";
+                    int32_t field_value=-999999;
+                    cass_user_type_set_int32_by_name(cass_np_meta, field_name.c_str(), field_value);
+                    CassError rc = cass_statement_bind_user_type(statement, bind_pos, cass_np_meta);
+                    CHECK_CASS("TupleRowFactory: Cassandra binding query unsuccessful [UDT], column:" +
+                               metadata->at(i).info.begin()->second);
+
+
+
+                    break;
+
+                }
                 case CASS_VALUE_TYPE_DECIMAL:
                 case CASS_VALUE_TYPE_TIMEUUID:
                 case CASS_VALUE_TYPE_INET:
                 case CASS_VALUE_TYPE_LIST:
                 case CASS_VALUE_TYPE_MAP:
                 case CASS_VALUE_TYPE_SET:
-                case CASS_VALUE_TYPE_UDT:
                 case CASS_VALUE_TYPE_CUSTOM:
                 case CASS_VALUE_TYPE_UNKNOWN:
                 default:

--- a/hecuba_core/tests/meta_manager_tests.cpp
+++ b/hecuba_core/tests/meta_manager_tests.cpp
@@ -16,7 +16,9 @@ const std::string create_ksp = "CREATE KEYSPACE " + keyspace +
                                +" WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};";
 const std::string drop_ksp = "DROP KEYSPACE IF EXISTS " + keyspace + ";";
 const std::string create_table = "CREATE TABLE " + keyspace + "." + table +
-                                 +"(storage_id uuid PRIMARY KEY, class_name text, name text);";
+                                 +"(storage_id uuid PRIMARY KEY, class_name text, name text, numpy_meta frozen<np_meta>);";
+
+const std::string create_np_dt = "CREATE TYPE IF NOT EXISTS "+ keyspace +" .np_meta(dims frozen<list<int>>,type int,block_id int);";
 
 /** TEST SETUP **/
 
@@ -51,6 +53,7 @@ void setupcassandra(std::string &contact_points, uint64_t nodePort) {
 
     fireandforget(drop_ksp);
     fireandforget(create_ksp);
+    fireandforget(create_np_dt);
     fireandforget(create_table);
 }
 
@@ -74,7 +77,7 @@ int main(int argc, char **argv) {
 
     int ret_code = RUN_ALL_TESTS();
 
-    teardown();
+    //teardown();
 
     return ret_code;
 }
@@ -82,7 +85,7 @@ int main(int argc, char **argv) {
 
 TEST(TestMetaManager, RegisterObj) {
     std::vector<std::map<std::string, std::string> > keysnames = {{{"name", "storage_id"}}};
-    std::vector<std::map<std::string, std::string> > colsnames = {{{"name", "name"}}};
+    std::vector<std::map<std::string, std::string> > colsnames = {{{"name", "name"}},{{"name","numpy_meta"}}};
 
     std::map<std::string, std::string> config;
     config["writer_par"] = "1";

--- a/hecuba_core/tests/meta_manager_tests.cpp
+++ b/hecuba_core/tests/meta_manager_tests.cpp
@@ -1,0 +1,178 @@
+#include <iostream>
+#include <cassandra.h>
+#include "gtest/gtest.h"
+#include "../src/MetaManager.h"
+#include "../src/StorageInterface.h"
+
+
+CassSession *test_session = nullptr;
+CassCluster *test_cluster = nullptr;
+
+const std::string table = "hfetch_test";
+const std::string keyspace = "test";
+
+// CQL statements
+const std::string create_ksp = "CREATE KEYSPACE " + keyspace +
+                               +" WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};";
+const std::string drop_ksp = "DROP KEYSPACE IF EXISTS " + keyspace + ";";
+const std::string create_table = "CREATE TABLE " + keyspace + "." + table +
+                                 +"(storage_id uuid PRIMARY KEY, class_name text, name text);";
+
+/** TEST SETUP **/
+
+void fireandforget(const std::string &query) {
+    std::cout << "EXECUTING " << query << std::endl;
+    CassStatement *statement = cass_statement_new(query.c_str(), 0);
+    CassFuture *connect_future = cass_session_execute(test_session, statement);
+    CassError rc = cass_future_error_code(connect_future);
+    if (rc != CASS_OK) {
+        std::cout << "ERROR ON EXECUTING QUERY: " << cass_error_desc(rc) << std::endl;
+    }
+    EXPECT_TRUE(rc == CASS_OK);
+    cass_future_free(connect_future);
+    cass_statement_free(statement);
+}
+
+
+void setupcassandra(std::string &contact_points, uint64_t nodePort) {
+
+    CassFuture *connect_future = nullptr;
+    test_cluster = cass_cluster_new();
+    test_session = cass_session_new();
+
+    cass_cluster_set_contact_points(test_cluster, contact_points.c_str());
+    cass_cluster_set_port(test_cluster, nodePort);
+
+    connect_future = cass_session_connect(test_session, test_cluster);
+    CassError rc = cass_future_error_code(connect_future);
+    cass_future_free(connect_future);
+
+    EXPECT_TRUE(rc == CASS_OK);
+
+    fireandforget(drop_ksp);
+    fireandforget(create_ksp);
+    fireandforget(create_table);
+}
+
+void teardown() {
+    if (test_session != nullptr) {
+        CassFuture *close_future = cass_session_close(test_session);
+        cass_future_free(close_future);
+        cass_session_free(test_session);
+        cass_cluster_free(test_cluster);
+        test_session = nullptr;
+    }
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+
+    std::string contact_p = "127.0.0.1";
+    uint32_t nodePort = 9042;
+
+    setupcassandra(contact_p, nodePort);
+
+    int ret_code = RUN_ALL_TESTS();
+
+    teardown();
+
+    return ret_code;
+}
+
+
+TEST(TestMetaManager, RegisterObj) {
+    std::vector<std::map<std::string, std::string> > keysnames = {{{"name", "storage_id"}}};
+    std::vector<std::map<std::string, std::string> > colsnames = {{{"name", "name"}}};
+
+    std::map<std::string, std::string> config;
+    config["writer_par"] = "1";
+    config["writer_buffer"] = "1";
+    config["timestamped_writes"] = "false";
+
+
+    TableMetadata *table_meta = new TableMetadata(table.c_str(), keyspace.c_str(), keysnames, colsnames, test_session);
+
+    MetaManager *meta_manager = new MetaManager(table_meta, test_session, config);
+
+
+    uint64_t *storage_id = new uint64_t[2]{4984489798, 78587497499};
+    CassUuid cass_uuid = {storage_id[0], storage_id[1]};
+
+    std::string obj_name = "obj_name_0";
+    ArrayMetadata *metas = nullptr;
+
+    meta_manager->register_obj(storage_id, obj_name, metas);
+
+    std::string istorage_select = "SELECT name FROM " + keyspace + "." + table + " WHERE storage_id=?";
+    CassStatement *statement = cass_statement_new(istorage_select.c_str(), 1);
+
+    cass_statement_bind_uuid(statement, 0, cass_uuid);
+    CassFuture *connect_future = cass_session_execute(test_session, statement);
+    CassError rc = cass_future_error_code(connect_future);
+
+    if (rc != CASS_OK) {
+        std::cerr << "Meta Manager failure" << std::endl;
+        std::cerr << std::string(cass_error_desc(rc)) << std::endl;
+        std::cerr << istorage_select << std::endl;
+
+    }
+
+    EXPECT_TRUE(rc == CASS_OK);
+    cass_future_free(connect_future);
+    cass_statement_free(statement);
+
+    delete (meta_manager);
+    delete (table_meta);
+}
+
+
+TEST(TestMetaManager, StorageInterfaceMake) {
+    std::string contact_p = "127.0.0.1";
+    uint32_t nodePort = 9042;
+
+    StorageInterface *SI = new StorageInterface(nodePort, contact_p);
+
+    EXPECT_NE(SI, nullptr);
+
+
+    std::vector<std::map<std::string, std::string> > keysnames = {{{"name", "storage_id"}}};
+    std::vector<std::map<std::string, std::string> > colsnames = {{{"name", "name"}}};
+
+    std::map<std::string, std::string> config;
+    config["writer_par"] = "1";
+    config["writer_buffer"] = "1";
+    config["timestamped_writes"] = "false";
+
+
+    MetaManager *meta_manager = SI->make_meta_manager(table.c_str(), keyspace.c_str(), keysnames, colsnames, config);
+
+
+    uint64_t *storage_id = new uint64_t[2]{123456789123456789, 123456789123456789};
+    CassUuid cass_uuid = {storage_id[0], storage_id[1]};
+
+    std::string obj_name = "obj_name_2";
+    ArrayMetadata *metas = nullptr;
+
+    meta_manager->register_obj(storage_id, obj_name, metas);
+
+    std::string istorage_select = "SELECT name FROM " + keyspace + "." + table + " WHERE storage_id=?";
+    CassStatement *statement = cass_statement_new(istorage_select.c_str(), 1);
+
+    cass_statement_bind_uuid(statement, 0, cass_uuid);
+    CassFuture *connect_future = cass_session_execute(test_session, statement);
+    CassError rc = cass_future_error_code(connect_future);
+
+    if (rc != CASS_OK) {
+        std::cerr << "Meta Manager failure" << std::endl;
+        std::cerr << std::string(cass_error_desc(rc)) << std::endl;
+        std::cerr << istorage_select << std::endl;
+
+    }
+
+    EXPECT_TRUE(rc == CASS_OK);
+    cass_future_free(connect_future);
+    cass_statement_free(statement);
+
+    delete (meta_manager);
+    delete (SI);
+}


### PR DESCRIPTION
The scope of this branch was to register Hecuba objects to `hecuba.istorage` from C++. In this way, when we load them from Python they are registered and created successfully.

Also, a nice addition was to include in this metadata manager the distributed creation of tables. Related to how do you create a table from many processes without crashing Cassandra.