### PR TITLE
Solve a problem with storage_api_tests failing

### DIFF
--- a/hecuba_py/tests/withcassandra/storage_api_tests.py
+++ b/hecuba_py/tests/withcassandra/storage_api_tests.py
@@ -2,7 +2,8 @@ import unittest
 
 from storage.api import getByID
 from ..app.words import Words
-from storage.api import StorageDict, StorageObject, StorageNumpy
+from hecuba import StorageDict, StorageNumpy
+from hecuba import StorageObj as StorageObject
 
 
 class ApiTestSDict(StorageDict):


### PR DESCRIPTION
    * The test was using an import StorageObject from storage.api, but
    this is not right. Because it does not export this object. Instead
    import from hecuba directly.