### PR TITLE
Solve a problem with storage_api_tests failing

### DIFF
--- a/.travis/build-wheels.sh
+++ b/.travis/build-wheels.sh
@@ -28,7 +28,7 @@ cd build;make;make install
 
 # getting TBB
 cd;curl -L https://github.com/intel/tbb/archive/v2020.0.tar.gz|tar -xz
-cd tbb-2020.0/
+cd oneTBB-2020.0/
 make tbb
 cp -r build/*_release/libtbb.so*  /usr/lib64
 cp -r include/tbb /usr/include

--- a/hecuba_py/tests/withcassandra/storage_api_tests.py
+++ b/hecuba_py/tests/withcassandra/storage_api_tests.py
@@ -2,7 +2,8 @@ import unittest
 
 from storage.api import getByID
 from ..app.words import Words
-from storage.api import StorageDict, StorageObject, StorageNumpy
+from hecuba import StorageDict, StorageNumpy
+from hecuba import StorageObj as StorageObject
 
 
 class ApiTestSDict(StorageDict):


### PR DESCRIPTION
    * The test was using an import StorageObject from storage.api, but
    this is not right. Because it does not export this object. Instead
    import from hecuba directly.