### PR TITLE
Reshape

### DIFF
--- a/hecuba_core/src/py_interface/HCache.cpp
+++ b/hecuba_core/src/py_interface/HCache.cpp
@@ -452,18 +452,15 @@ static PyObject *get_elements_per_row(HNumpyStore *self, PyObject *args) {
     HArrayMetadata *np_metas = reinterpret_cast<HArrayMetadata *>(py_np_metas);
 
     const uint64_t *storage_id = parse_uuid(py_keys);
-    PyObject *obj;
+    PyObject *obj=Py_None;
     try {
         obj = self->NumpyDataStore->get_row_elements(storage_id, np_metas->np_metas);
     }
     catch (std::exception &e) {
         PyErr_SetString(PyExc_RuntimeError, e.what());
-        return NULL;
     }
     delete[] storage_id;
-    PyObject *result_list = PyList_New(1);
-    PyList_SetItem(result_list, 0, obj ? obj : Py_None);
-    return result_list;
+    return obj;
 }
 
 static PyObject *allocate_numpy(HNumpyStore *self, PyObject *args) {

--- a/hecuba_py/hecuba/hdict.py
+++ b/hecuba_py/hecuba/hdict.py
@@ -632,7 +632,7 @@ class StorageDict(IStorage, dict):
                 vals_istorage.append(val_istorage)
 
             val = vals_istorage
-        elif isinstance(val, np.ndarray):
+        elif isinstance(val, np.ndarray) and not isinstance(val, StorageNumpy):
             val = StorageNumpy(val)
         elif isinstance(val, set):
             val = self.__create_embeddedset(key=key, val=val)

--- a/hecuba_py/hecuba/hnumpy.py
+++ b/hecuba_py/hecuba/hnumpy.py
@@ -52,7 +52,7 @@ class StorageNumpy(IStorage, np.ndarray):
             (obj._ksp, obj._table) = extract_ks_tab(name)
             obj._hcache = result[1]
             obj.storage_id = storage_id
-            obj._row_elem = obj._hcache.get_elements_per_row(obj.storage_id, base_metas)[0]
+            obj._row_elem = obj._hcache.get_elements_per_row(obj.storage_id, base_metas)
             if base_numpy is not None:
                 obj._partition_dims = numpy_metadata.dims
         else:
@@ -261,7 +261,7 @@ class StorageNumpy(IStorage, np.ndarray):
             self._hcache.store_numpy_slices([self.storage_id], self._build_args.metas, [self.base.view(np.ndarray)],
                                             None)
         StorageNumpy._store_meta(self._build_args)
-        self._row_elem = self._hcache.get_elements_per_row(self.storage_id, self._build_args.metas)[0]
+        self._row_elem = self._hcache.get_elements_per_row(self.storage_id, self._build_args.metas)
 
     def stop_persistent(self):
         super().stop_persistent()


### PR DESCRIPTION
 This merge adds support for storing different Metadata for the same data. It allows to create a new StorageNumpy from a previous StorageNumpy, creating a view of it, with a new StorageID and keeping a pointer (base) to the original one. No persistance is allowed for these new objects.