### PR TITLE
Fix linking problem with google tests.

### DIFF
--- a/hecuba_core/CMakeLists.txt
+++ b/hecuba_core/CMakeLists.txt
@@ -231,7 +231,7 @@ if (DEFINED ENV{GTEST_ROOT})
             add_executable(hfetch_test tests/runtests.cpp)
             set_target_properties(hfetch_test
                     PROPERTIES BUILD_WITH_INSTALL_RPATH 0)
-            target_link_libraries(hfetch_test ${ALL_LIBS} ${PT} ${GTEST_BOTH_LIBRARIES} hfetch)
+            target_link_libraries(hfetch_test ${ALL_LIBS} ${GTEST_BOTH_LIBRARIES} hfetch ${PT})
             add_dependencies(hfetch_test hfetch)
 
             add_test(test hfetch_test)

--- a/hecuba_core/tests/runtests.cpp
+++ b/hecuba_core/tests/runtests.cpp
@@ -173,17 +173,16 @@ TEST(TestTBBQueue, Try_pop) {
 TEST(TestZorder, Zorder) {
     std::vector<uint32_t> ccs = {0, 0, 0, 2}; //row 3, column 2
     SpaceFillingCurve SP;
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    arr_metas->dims = {4, 4, 4, 4};
-    arr_metas->elem_size = sizeof(uint32_t);
-    arr_metas->partition_type = ZORDER_ALGORITHM;
+    ArrayMetadata arr_metas = ArrayMetadata();
+    arr_metas.dims = {4, 4, 4, 4};
+    arr_metas.elem_size = sizeof(uint32_t);
+    arr_metas.partition_type = ZORDER_ALGORITHM;
 
 
     ZorderCurveGenerator *partitioner = new ZorderCurveGenerator(arr_metas, nullptr);
     uint64_t result = partitioner->computeZorder(ccs);
     uint64_t expected_zorder = 128;
     EXPECT_EQ(expected_zorder, result);
-    delete (arr_metas);
     delete (partitioner);
 }
 
@@ -248,11 +247,10 @@ TEST(TestMakePartitions, 2DZorder) {
     uint32_t nrows = 463;
     uint32_t ncols = 53;
     std::vector<uint32_t> ccs = {nrows, ncols};
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    arr_metas->dims = ccs;
-    arr_metas->inner_type = CASS_VALUE_TYPE_INT;
-    arr_metas->elem_size = sizeof(int32_t);
-    arr_metas->partition_type = ZORDER_ALGORITHM;
+    ArrayMetadata arr_metas = ArrayMetadata();
+    arr_metas.dims = ccs;
+    arr_metas.elem_size = sizeof(int32_t);
+    arr_metas.partition_type = ZORDER_ALGORITHM;
 
     int32_t *data = new int32_t[ncols * nrows];
     for (uint32_t row = 0; row < nrows; ++row) {
@@ -268,7 +266,7 @@ TEST(TestMakePartitions, 2DZorder) {
     while (!partitioner->isDone()) {
         Partition chunk = partitioner->getNextPartition();
         uint64_t *size = (uint64_t *) chunk.data;
-        uint64_t nelem = *size / arr_metas->elem_size;
+        uint64_t nelem = *size / arr_metas.elem_size;
         total_elem += nelem;
         int32_t *chunk_data = (int32_t *) ((char *) chunk.data + sizeof(uint64_t));
         for (uint64_t pos = 0; pos < nelem; ++pos) {
@@ -288,7 +286,6 @@ TEST(TestMakePartitions, 2DZorder) {
     EXPECT_EQ(*elements_found.begin(), 0);
     EXPECT_EQ(*elements_found.rbegin(), ncols * nrows - 1);
     delete[](data);
-    delete (arr_metas);
     delete (partitioner);
 }
 
@@ -302,11 +299,10 @@ TEST(TestMakePartitions, 2DZorderZeroes) {
     uint32_t nrows = 463;
     uint32_t ncols = 53;
     std::vector<uint32_t> ccs = {nrows, ncols};
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    arr_metas->dims = ccs;
-    arr_metas->inner_type = CASS_VALUE_TYPE_DOUBLE;
-    arr_metas->elem_size = sizeof(double);
-    arr_metas->partition_type = ZORDER_ALGORITHM;
+    ArrayMetadata arr_metas = ArrayMetadata();
+    arr_metas.dims = ccs;
+    arr_metas.elem_size = sizeof(double);
+    arr_metas.partition_type = ZORDER_ALGORITHM;
 
     double *data = new double[ncols * nrows];
     for (uint32_t row = 0; row < nrows; ++row) {
@@ -324,7 +320,7 @@ TEST(TestMakePartitions, 2DZorderZeroes) {
     while (!partitioner->isDone()) {
         Partition chunk = partitioner->getNextPartition();
         uint64_t *size = (uint64_t *) chunk.data;
-        uint64_t nelem = *size / arr_metas->elem_size;
+        uint64_t nelem = *size / arr_metas.elem_size;
         total_elem += nelem;
         double *chunk_data = (double *) ((char *) chunk.data + sizeof(uint64_t));
         for (uint64_t pos = 0; pos < nelem; ++pos) {
@@ -342,18 +338,16 @@ TEST(TestMakePartitions, 2DZorderZeroes) {
 
     //std::cout << "FInal memcmp " << memcmp(array,data,ncols*nrows*arr_metas->elem_size) << std::endl;
     delete[](data);
-    delete (arr_metas);
     delete (partitioner);
 }
 
 //Test to analyze the partitioning of a small 3D array
 TEST(TestMakePartitions, 3DZorder_Small) {
     std::vector<uint32_t> ccs = {17, 17, 17};
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    arr_metas->dims = ccs;
-    arr_metas->inner_type = CASS_VALUE_TYPE_INT;
-    arr_metas->elem_size = sizeof(int32_t);
-    arr_metas->partition_type = ZORDER_ALGORITHM;
+    ArrayMetadata arr_metas = ArrayMetadata();
+    arr_metas.dims = ccs;
+    arr_metas.elem_size = sizeof(int32_t);
+    arr_metas.partition_type = ZORDER_ALGORITHM;
 
     uint64_t arr_size = 1;
     for (uint32_t size_dim:ccs) {
@@ -373,7 +367,7 @@ TEST(TestMakePartitions, 3DZorder_Small) {
     while (!partitioner->isDone()) {
         Partition chunk = partitioner->getNextPartition();
         uint64_t *size = (uint64_t *) chunk.data;
-        uint64_t nelem = *size / arr_metas->elem_size;
+        uint64_t nelem = *size / arr_metas.elem_size;
         total_elem += nelem;
         int32_t *chunk_data = (int32_t *) ((char *) chunk.data + sizeof(uint64_t));
         for (uint64_t pos = 0; pos < nelem; ++pos) {
@@ -397,18 +391,16 @@ TEST(TestMakePartitions, 3DZorder_Small) {
     EXPECT_EQ(total_elem, max_elem);
     EXPECT_EQ(elements_found.size(), max_elem);
     delete[](data);
-    delete (arr_metas);
     delete (partitioner);
 }
 
 //Test to analyze the partitioning of a medium 3D array, approx 72MB
 TEST(TestMakePartitions, 3DZorder_Medium) {
     std::vector<uint32_t> ccs = {250, 150, 500};
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    arr_metas->dims = ccs;
-    arr_metas->inner_type = CASS_VALUE_TYPE_INT;
-    arr_metas->elem_size = sizeof(int32_t);
-    arr_metas->partition_type = ZORDER_ALGORITHM;
+    ArrayMetadata arr_metas =  ArrayMetadata();
+    arr_metas.dims = ccs;
+    arr_metas.elem_size = sizeof(int32_t);
+    arr_metas.partition_type = ZORDER_ALGORITHM;
 
     uint64_t arr_size = 1;
     for (uint32_t size_dim:ccs) {
@@ -428,7 +420,7 @@ TEST(TestMakePartitions, 3DZorder_Medium) {
     while (!partitioner->isDone()) {
         Partition chunk = partitioner->getNextPartition();
         uint64_t *size = (uint64_t *) chunk.data;
-        uint64_t nelem = *size / arr_metas->elem_size;
+        uint64_t nelem = *size / arr_metas.elem_size;
         total_elem += nelem;
         int32_t *chunk_data = (int32_t *) ((char *) chunk.data + sizeof(uint64_t));
         for (uint64_t pos = 0; pos < nelem; ++pos) {
@@ -453,18 +445,16 @@ TEST(TestMakePartitions, 3DZorder_Medium) {
     }
     EXPECT_EQ(total_elem, max_elem);
     delete[](data);
-    delete (arr_metas);
 }
 
 
 //Test to analyze the partitioning of a big 3D array, approx 256MB
 TEST(TestMakePartitions, 3DZorder_Big) {
     std::vector<uint32_t> ccs = {512, 512, 512};
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    arr_metas->dims = ccs;
-    arr_metas->inner_type = CASS_VALUE_TYPE_INT;
-    arr_metas->elem_size = sizeof(int32_t);
-    arr_metas->partition_type = ZORDER_ALGORITHM;
+    ArrayMetadata arr_metas = ArrayMetadata();
+    arr_metas.dims = ccs;
+    arr_metas.elem_size = sizeof(int32_t);
+    arr_metas.partition_type = ZORDER_ALGORITHM;
 
     uint64_t arr_size = 1;
     for (int32_t size_dim:ccs) {
@@ -484,7 +474,7 @@ TEST(TestMakePartitions, 3DZorder_Big) {
     while (!partitioner->isDone()) {
         Partition chunk = partitioner->getNextPartition();
         uint64_t *size = (uint64_t *) chunk.data;
-        uint64_t nelem = *size / arr_metas->elem_size;
+        uint64_t nelem = *size / arr_metas.elem_size;
         total_elem += nelem;
         int32_t *chunk_data = (int32_t *) ((char *) chunk.data + sizeof(uint64_t));
         for (uint64_t pos = 0; pos < nelem; ++pos) {
@@ -510,7 +500,6 @@ TEST(TestMakePartitions, 3DZorder_Big) {
     }
     EXPECT_EQ(total_elem, max_elem);
     delete[](data);
-    delete (arr_metas);
 
 }
 
@@ -518,12 +507,11 @@ TEST(TestMakePartitions, 3DZorder_Big) {
 TEST(TestMakePartitions, NDZorder) {
     uint32_t max_dims = 6;
     std::vector<uint32_t> ccs = {17};
-    ArrayMetadata *arr_metas = new ArrayMetadata();
+    ArrayMetadata arr_metas = ArrayMetadata();
     while (ccs.size() <= max_dims) {
-        arr_metas->dims = ccs;
-        arr_metas->inner_type = CASS_VALUE_TYPE_INT;
-        arr_metas->elem_size = sizeof(int32_t);
-        arr_metas->partition_type = ZORDER_ALGORITHM;
+        arr_metas.dims = ccs;
+        arr_metas.elem_size = sizeof(int32_t);
+        arr_metas.partition_type = ZORDER_ALGORITHM;
 
         uint64_t arr_size = 1;
         for (int32_t size_dim:ccs) {
@@ -543,7 +531,7 @@ TEST(TestMakePartitions, NDZorder) {
         while (!partitioner->isDone()) {
             Partition chunk = partitioner->getNextPartition();
             uint64_t *size = (uint64_t *) chunk.data;
-            uint64_t nelem = *size / arr_metas->elem_size;
+            uint64_t nelem = *size / arr_metas.elem_size;
             total_elem += nelem;
             int32_t *chunk_data = (int32_t *) ((char *) chunk.data + sizeof(uint64_t));
             for (uint64_t pos = 0; pos < nelem; ++pos) {
@@ -573,7 +561,6 @@ TEST(TestMakePartitions, NDZorder) {
         ccs.push_back(17);
     }
 
-    delete (arr_metas);
 
 }
 
@@ -582,11 +569,10 @@ TEST(TestMakePartitions, 2DZorder128Double) {
     uint32_t ncols = 1000;
     uint32_t nrows = 1000;
     std::vector<uint32_t> ccs = {nrows, ncols}; //4D 128 elements
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    arr_metas->dims = ccs;
-    arr_metas->inner_type = CASS_VALUE_TYPE_DOUBLE;
-    arr_metas->elem_size = sizeof(double);
-    arr_metas->partition_type = ZORDER_ALGORITHM;
+    ArrayMetadata arr_metas = ArrayMetadata();
+    arr_metas.dims = ccs;
+    arr_metas.elem_size = sizeof(double);
+    arr_metas.partition_type = ZORDER_ALGORITHM;
 
 
     uint64_t arr_size = 1;
@@ -608,7 +594,7 @@ TEST(TestMakePartitions, 2DZorder128Double) {
     while (!partitioner->isDone()) {
         Partition chunk = partitioner->getNextPartition();
         uint64_t *size = (uint64_t *) chunk.data;
-        uint64_t nelem = *size / arr_metas->elem_size;
+        uint64_t nelem = *size / arr_metas.elem_size;
         total_elem += nelem;
         double *chunk_data = (double *) ((char *) chunk.data + sizeof(uint64_t));
         for (uint64_t pos = 0; pos < nelem; ++pos) {
@@ -627,7 +613,6 @@ TEST(TestMakePartitions, 2DZorder128Double) {
     EXPECT_EQ(*elements_found.begin(), 0);
     EXPECT_EQ(*elements_found.rbegin(), ncols * nrows - 1);
     delete[](data);
-    delete (arr_metas);
     delete (partitioner);
 }
 
@@ -641,11 +626,10 @@ TEST(TestMakePartitions, 2DZorderByRange) {
     for (uint32_t ncols = 1; ncols < maxcols; ++ncols) {
         for (uint32_t nrows = 1; nrows < maxrows; ++nrows) {
             std::vector<uint32_t> ccs = {nrows, ncols}; //4D 128 elements
-            ArrayMetadata *arr_metas = new ArrayMetadata();
-            arr_metas->dims = ccs;
-            arr_metas->inner_type = CASS_VALUE_TYPE_DOUBLE;
-            arr_metas->elem_size = sizeof(double);
-            arr_metas->partition_type = ZORDER_ALGORITHM;
+            ArrayMetadata arr_metas = ArrayMetadata();
+            arr_metas.dims = ccs;
+            arr_metas.elem_size = sizeof(double);
+            arr_metas.partition_type = ZORDER_ALGORITHM;
 
             uint64_t arr_size = 1;
             for (int32_t size_dim:ccs) {
@@ -666,7 +650,7 @@ TEST(TestMakePartitions, 2DZorderByRange) {
             while (!partitioner->isDone()) {
                 Partition chunk = partitioner->getNextPartition();
                 uint64_t *size = (uint64_t *) chunk.data;
-                uint64_t nelem = *size / arr_metas->elem_size;
+                uint64_t nelem = *size / arr_metas.elem_size;
                 total_elem += nelem;
                 double *chunk_data = (double *) ((char *) chunk.data + sizeof(uint64_t));
                 for (uint64_t pos = 0; pos < nelem; ++pos) {
@@ -693,7 +677,6 @@ TEST(TestMakePartitions, 2DZorderByRange) {
             EXPECT_EQ(total_elem, ncols * nrows);
             EXPECT_EQ(elements_found.size(), ncols * nrows);
             delete[](data);
-            delete (arr_metas);
         }
     }
 }
@@ -706,11 +689,10 @@ TEST(TestMakePartitions, 2DNopart) {
     uint32_t ncols = 1104;
     int32_t arr_size = ncols * nrows;
     std::vector<uint32_t> ccs = {ncols, nrows};
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    arr_metas->dims = ccs;
-    arr_metas->inner_type = CASS_VALUE_TYPE_INT;
-    arr_metas->elem_size = sizeof(int32_t);
-    arr_metas->partition_type = NO_PARTITIONS;
+    ArrayMetadata arr_metas = ArrayMetadata();
+    arr_metas.dims = ccs;
+    arr_metas.elem_size = sizeof(int32_t);
+    arr_metas.partition_type = NO_PARTITIONS;
 
     int32_t *data = new int32_t[arr_size];
     for (uint32_t col = 0; col < ncols; ++col) {
@@ -723,13 +705,12 @@ TEST(TestMakePartitions, 2DNopart) {
     Partition part = partitioner->getNextPartition();
     EXPECT_TRUE(partitioner->isDone());
     uint64_t *chunk_size = (uint64_t *) part.data;
-    EXPECT_EQ(*chunk_size, arr_size * arr_metas->elem_size);
+    EXPECT_EQ(*chunk_size, arr_size * arr_metas.elem_size);
     char *partition_data = ((char *) part.data) + sizeof(uint64_t);
     int32_t equal = memcmp(partition_data, data, arr_size * sizeof(int32_t));
     EXPECT_TRUE(equal == 0);
     EXPECT_FALSE(data == (int32_t *) partition_data);
     delete[](data);
-    delete (arr_metas);
     delete (partitioner);
 }
 
@@ -740,11 +721,10 @@ TEST(TestMakePartitions, 2DNopart) {
 // into a single array and make sure both processes performed correctly
 TEST(TestMakePartitions, 3DZorderAndReverse) {
     std::vector<uint32_t> ccs = {256, 256, 256};
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    arr_metas->dims = ccs;
-    arr_metas->inner_type = CASS_VALUE_TYPE_INT;
-    arr_metas->elem_size = sizeof(int32_t);
-    arr_metas->partition_type = ZORDER_ALGORITHM;
+    ArrayMetadata arr_metas = ArrayMetadata();
+    arr_metas.dims = ccs;
+    arr_metas.elem_size = sizeof(int32_t);
+    arr_metas.partition_type = ZORDER_ALGORITHM;
 
     uint64_t arr_size = 1;
     for (int32_t size_dim:ccs) {
@@ -762,7 +742,7 @@ TEST(TestMakePartitions, 3DZorderAndReverse) {
     while (!partitioner->isDone()) {
         Partition chunk = partitioner->getNextPartition();
         uint64_t *size = (uint64_t *) chunk.data;
-        uint64_t nelem = *size / arr_metas->elem_size;
+        uint64_t nelem = *size / arr_metas.elem_size;
         total_elem += nelem;
         int32_t *chunk_data = (int32_t *) ((char *) chunk.data + sizeof(uint64_t));
         for (uint64_t pos = 0; pos < nelem; ++pos) {
@@ -795,11 +775,10 @@ TEST(TestMakePartitions, 3DZorderAndReverse) {
 // into a single array and make sure both processes performed correctly
 TEST(TestMakePartitions, 4DZorderAndReverse) {
     std::vector<uint32_t> ccs = {100, 20, 150, 30};
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    arr_metas->dims = ccs;
-    arr_metas->inner_type = CASS_VALUE_TYPE_INT;
-    arr_metas->elem_size = sizeof(int32_t);
-    arr_metas->partition_type = ZORDER_ALGORITHM;
+    ArrayMetadata arr_metas = ArrayMetadata();
+    arr_metas.dims = ccs;
+    arr_metas.elem_size = sizeof(int32_t);
+    arr_metas.partition_type = ZORDER_ALGORITHM;
 
     uint64_t arr_size = 1;
     for (int32_t size_dim:ccs) {
@@ -817,7 +796,7 @@ TEST(TestMakePartitions, 4DZorderAndReverse) {
     while (!partitioner->isDone()) {
         Partition chunk = partitioner->getNextPartition();
         uint64_t *size = (uint64_t *) chunk.data;
-        uint64_t nelem = *size / arr_metas->elem_size;
+        uint64_t nelem = *size / arr_metas.elem_size;
         total_elem += nelem;
         int32_t *chunk_data = (int32_t *) ((char *) chunk.data + sizeof(uint64_t));
         for (uint64_t pos = 0; pos < nelem; ++pos) {
@@ -849,11 +828,10 @@ TEST(TestMakePartitions, ReadBlockOnlyOnce) {
     uint32_t nrows = 463;
     uint32_t ncols = 53;
     std::vector<uint32_t> ccs = {nrows, ncols};
-    ArrayMetadata *arr_metas = new ArrayMetadata();
-    arr_metas->dims = ccs;
-    arr_metas->inner_type = CASS_VALUE_TYPE_INT;
-    arr_metas->elem_size = sizeof(int32_t);
-    arr_metas->partition_type = ZORDER_ALGORITHM;
+    ArrayMetadata arr_metas = ArrayMetadata();
+    arr_metas.dims = ccs;
+    arr_metas.elem_size = sizeof(int32_t);
+    arr_metas.partition_type = ZORDER_ALGORITHM;
 
     int32_t *data = new int32_t[ncols * nrows];
     for (uint32_t row = 0; row < nrows; ++row) {
@@ -873,7 +851,7 @@ TEST(TestMakePartitions, ReadBlockOnlyOnce) {
     while (!partitioner->isDone()) {
         Partition chunk = partitioner->getNextPartition();
         uint64_t *size = (uint64_t *) chunk.data;
-        uint64_t nelem = *size / arr_metas->elem_size;
+        uint64_t nelem = *size / arr_metas.elem_size;
         total_elem += nelem;
         int32_t *chunk_data = (int32_t *) ((char *) chunk.data + sizeof(uint64_t));
         for (uint64_t pos = 0; pos < nelem; ++pos) {
@@ -921,7 +899,6 @@ TEST(TestMakePartitions, ReadBlockOnlyOnce) {
         //the cluster will be repeated
     }
 
-    delete (arr_metas);
     delete (partitioner);
 }
 


### PR DESCRIPTION
	* The pthreads library was set at the start of the linking line and the
	  linker complains about misssing symbols. Changing the order and putting
	  the library at the end, solves the issue.
	* Fix the runtests.cpp to use the right interface.