### PR TITLE
Fix management of loaded coordinates

### DIFF
--- a/hecuba_py/tests/withcassandra/storagenumpy_tests.py
+++ b/hecuba_py/tests/withcassandra/storagenumpy_tests.py
@@ -514,5 +514,20 @@ class StorageNumpyTest(unittest.TestCase):
 
         self.assertTrue(c[0,0]!=s[0,0])
 
+    def test_columnar_access(self):
+        # Test accessing a column that traverses different blocks in cassandra
+
+        n = np.arange(2*180).reshape(2,180)
+        s = StorageNumpy(n, "mykk")
+
+        del s
+
+        s = StorageNumpy(None, "mykk")
+
+        tmp=s[0,:]
+
+        self.assertTrue(np.array_equal(tmp, n[0,:]))
+        print(tmp)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
	* The numpy_full_loaded was wrongly calculated.
	* This fix stores all numpy coordinates in the object to avoid
	  recalculating them at each access.