### PR TITLE
Solve a problem with schema agreement

### DIFF
--- a/hecuba_core/src/TableMetadata.h
+++ b/hecuba_core/src/TableMetadata.h
@@ -115,6 +115,8 @@ private:
     std::shared_ptr<const std::vector<ColumnMeta> > items;
     std::string keyspace, table;
     std::string select, insert, select_tokens_all, select_tokens_values, select_keys_tokens, delete_row;
+    //bool checkSchemaAgreement(const CassSession *session);
+    const CassTableMeta *getCassTableMeta(const CassSession * session);
 
 };
 


### PR DESCRIPTION
	* This commit fixes a problem when due to different process creating
	  tables in parallel, was accessing an snapshot of the schema metadata,
	  and therefore one of the tables was not detected. The solution passes
	  per accesing the schema metadata again.