### PR TITLE
Fix test errors

### DIFF
--- a/hecuba_py/tests/withcassandra/embeddedset_tests.py
+++ b/hecuba_py/tests/withcassandra/embeddedset_tests.py
@@ -48,7 +48,8 @@ class EmbeddedSetTest(unittest.TestCase):
         config.execution_name = self.current_ksp
 
     def tearDown(self):
-        config.session.execute("DROP KEYSPACE IF EXISTS {}".format(self.current_ksp))
+        #config.session.execute("DROP KEYSPACE IF EXISTS {}".format(self.current_ksp))
+        pass
 
     def testAddRemove(self):
         d = DictSet2(self.current_ksp+".dictset")

--- a/hecuba_py/tests/withcassandra/hfetch_flush_tests.py
+++ b/hecuba_py/tests/withcassandra/hfetch_flush_tests.py
@@ -12,11 +12,12 @@ class StorageDictTest(unittest.TestCase):
 
     @staticmethod
     def tearDownClass():
-        config.session.execute(
-                "DROP KEYSPACE ksp;")
+        config.session.execute( "DROP KEYSPACE ksp;")
+        pass
 
     def tearDown(self):
-        config.session.execute("DROP TABLE IF EXISTS ksp.tb1")
+        config.session.execute("DROP TABLE IF EXISTS ksp.tb1", timeout=60)
+        pass
 
     def test_flush_items_100(self):
         config.session.execute("CREATE TABLE ksp.tb1(pk1 int, val1 text,PRIMARY KEY(pk1))")

--- a/hecuba_py/tests/withcassandra/hfilter_tests.py
+++ b/hecuba_py/tests/withcassandra/hfilter_tests.py
@@ -32,7 +32,8 @@ class LambdaParserTest(unittest.TestCase):
         config.execution_name = self.current_ksp
 
     def tearDown(self):
-        config.session.execute("DROP KEYSPACE IF EXISTS {}".format(self.current_ksp))
+        #config.session.execute("DROP KEYSPACE IF EXISTS {}".format(self.current_ksp))
+        pass
 
     def test_simple_filter(self):
         simple_dict = SimpleDict("simpledict")

--- a/hecuba_py/tests/withcassandra/istorage_tests.py
+++ b/hecuba_py/tests/withcassandra/istorage_tests.py
@@ -27,7 +27,8 @@ class IStorageTests(unittest.TestCase):
         config.execution_name = self.current_ksp
 
     def tearDown(self):
-        config.session.execute("DROP KEYSPACE IF EXISTS {}".format(self.current_ksp))
+        #config.session.execute("DROP KEYSPACE IF EXISTS {}".format(self.current_ksp))
+        pass
 
     def stop_persistent_method_test(self):
         key = 123

--- a/hecuba_py/tests/withcassandra/storage_api_tests.py
+++ b/hecuba_py/tests/withcassandra/storage_api_tests.py
@@ -37,7 +37,8 @@ class StorageApi_Tests(unittest.TestCase):
         config.execution_name = self.current_ksp
 
     def tearDown(self):
-        config.session.execute("DROP KEYSPACE IF EXISTS {}".format(self.current_ksp))
+        #config.session.execute("DROP KEYSPACE IF EXISTS {}".format(self.current_ksp))
+        pass
 
     def class_type_test(self):
         base_dict = ApiTestSDict('api_sdict')

--- a/hecuba_py/tests/withcassandra/storagedict_split_tests.py
+++ b/hecuba_py/tests/withcassandra/storagedict_split_tests.py
@@ -346,14 +346,14 @@ class StorageDictSlitTestVnodes(StorageDictSplitTestbase):
         importlib.reload(hfetch)
         import importlib
         importlib.reload(hecuba)
-        config.session.execute("DROP KEYSPACE IF EXISTS my_app")
+        config.session.execute("DROP KEYSPACE IF EXISTS my_app", timeout=60)
         config.session.execute(
             "CREATE KEYSPACE IF NOT EXISTS my_app WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};")
         super(StorageDictSplitTestbase, cls).setUpClass()
 
     @classmethod
     def tearDownClass(cls):
-        config.session.execute("DROP KEYSPACE IF EXISTS my_app")
+        config.session.execute("DROP KEYSPACE IF EXISTS my_app", timeout=60)
         from .. import test_config
         from hfetch import disconnectCassandra
         disconnectCassandra()

--- a/hecuba_py/tests/withcassandra/storagedict_tests.py
+++ b/hecuba_py/tests/withcassandra/storagedict_tests.py
@@ -139,7 +139,8 @@ class StorageDictTest(unittest.TestCase):
         config.execution_name = self.current_ksp
 
     def tearDown(self):
-        config.session.execute("DROP KEYSPACE IF EXISTS {}".format(self.current_ksp))
+        #config.session.execute("DROP KEYSPACE IF EXISTS {}".format(self.current_ksp))
+        pass
 
     def test_init_empty(self):
         tablename = self.current_ksp+".tab1"

--- a/hecuba_py/tests/withcassandra/storagenumpy_tests.py
+++ b/hecuba_py/tests/withcassandra/storagenumpy_tests.py
@@ -25,7 +25,8 @@ class StorageNumpyTest(unittest.TestCase):
         config.execution_name = self.ksp
 
     def tearDown(self):
-        config.session.execute("DROP KEYSPACE IF EXISTS {}".format(self.ksp))
+        #config.session.execute("DROP KEYSPACE IF EXISTS {}".format(self.ksp))
+        pass
 
     table = 'numpy_test'
 

--- a/hecuba_py/tests/withcassandra/storagenumpy_tests.py
+++ b/hecuba_py/tests/withcassandra/storagenumpy_tests.py
@@ -449,7 +449,7 @@ class StorageNumpyTest(unittest.TestCase):
 
         # Clean up
         s1.delete_persistent()
-        config.session.execute("DROP TABLE IF EXISTS my_app.test_storage_from_storage")
+        config.session.execute("DROP TABLE IF EXISTS my_app.test_storagenumpy_reshape")
 
     def test_transpose(self):
         '''

--- a/hecuba_py/tests/withcassandra/storageobj_split_tests.py
+++ b/hecuba_py/tests/withcassandra/storageobj_split_tests.py
@@ -33,7 +33,8 @@ class StorageObjSplitTest(unittest.TestCase):
         config.execution_name = self.ksp
 
     def tearDown(self):
-        config.session.execute("DROP KEYSPACE IF EXISTS {}".format(self.ksp))
+        #config.session.execute("DROP KEYSPACE IF EXISTS {}".format(self.ksp))
+        pass
 
     def test_simple_keys_split_test(self):
         tablename = "tab30"

--- a/hecuba_py/tests/withcassandra/storageobj_tests.py
+++ b/hecuba_py/tests/withcassandra/storageobj_tests.py
@@ -177,7 +177,8 @@ class StorageObjTest(unittest.TestCase):
         config.execution_name = self.current_ksp
 
     def tearDown(self):
-        config.session.execute("DROP KEYSPACE IF EXISTS {}".format(self.current_ksp))
+        #config.session.execute("DROP KEYSPACE IF EXISTS {}".format(self.current_ksp))
+        pass
 
     def test_build_remotely(self):
         obj = TestStorageObj(config.execution_name + ".tt1")

--- a/hecuba_py/tests/withcassandra/storageobj_with_numpy_tests.py
+++ b/hecuba_py/tests/withcassandra/storageobj_with_numpy_tests.py
@@ -28,7 +28,8 @@ class StorageNumpyTest(unittest.TestCase):
         config.execution_name = self.ksp
 
     def tearDown(self):
-        config.session.execute("DROP KEYSPACE IF EXISTS {}".format(self.ksp))
+        #config.session.execute("DROP KEYSPACE IF EXISTS {}".format(self.ksp))
+        pass
 
     table = 'numpy_test'
 

--- a/hecuba_py/tests/withcassandra/tutorial_tests.py
+++ b/hecuba_py/tests/withcassandra/tutorial_tests.py
@@ -103,7 +103,8 @@ class TutorialTest(unittest.TestCase):
         config.execution_name = self.current_ksp
 
     def tearDown(self):
-        config.session.execute("DROP KEYSPACE IF EXISTS {}".format(self.current_ksp))
+        #config.session.execute("DROP KEYSPACE IF EXISTS {}".format(self.current_ksp))
+        pass
 
 
     def test_init_storagedict_test(self):


### PR DESCRIPTION
DROP KEYSPACE takes a lot of time and therefore make the tests to fail
This test, simply removes these DROPs as the tests are volatile and unimportant data to preserve