### PR TITLE
Fix store a non loaded SN into a SN

### DIFF
--- a/hecuba_py/hecuba/hnumpy.py
+++ b/hecuba_py/hecuba/hnumpy.py
@@ -647,6 +647,9 @@ class StorageNumpy(IStorage, np.ndarray):
 
             #yolandab: execute first the super to modified the base numpy
 
+            if type(values)==StorageNumpy and not values._numpy_full_loaded:
+                values[:]  # LOAD the values as the numpy.__setitem__ will only use memory
+
             super(StorageNumpy, self).__setitem__(sliced_coord, values)
 
             base_numpy = StorageNumpy._get_base_array(self) # self.base is  numpy.ndarray


### PR DESCRIPTION
    * When storing a StorageNumpy (SN) into another (setitem(self, ...,
      values), it uses the numpy setitem which will not load the SN, it will
      just copy the memory used by it. Therefore it is needed to load the SN
      BEFORE calling the numpy setitem.