### PR TITLE
Avoid copying dependencies to install dir

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,6 @@ def setup_packages():
     if c_binding_path:
         PATH_INCLUDE += [c_binding_path + "/include"]
         PATH_LIBS += [c_binding_path + "/lib"]
-        extra_files = extra_files + package_files(c_binding_path + "/lib")
 
     extensions = [
         Extension(


### PR DESCRIPTION
    * In 044c793 the required libraries (dependencies) were being copied to the
      installation directory. This was done using the  'package_files' method
      which traverses the directory passed as argument and returns all files
      containing '.so' in the name... which is a problem when the dependencies
      directory coincides with the installation directory (--prefix=DIR
      --c_binding=DIR), as the installation directory already contains files
      with this pattern.

    * This commit disables this copy, forcing the use of LD_LIBRARY_PATH
      variable to refer to the dependant libraries.