### PR TITLE
Add support for unnamed types in dict

### DIFF
--- a/hecuba_py/tests/withcassandra/parser_hints_tests.py
+++ b/hecuba_py/tests/withcassandra/parser_hints_tests.py
@@ -35,9 +35,20 @@ class Dict4(StorageDict):
 # no <<key>, value> format
 class Dict5(StorageDict):
     '''
-    @TypeSpec <a:int, b:int>
+    @TypeSpec dict <a:int, b:int>
     '''
 
+# key without name
+class Dict6(StorageDict):
+    '''
+    @TypeSpec dict<<:int>, b:int>
+    '''
+
+# key without type
+class Dict7(StorageDict):
+    '''
+    @TypeSpec dict <<key:>, b:int>
+    '''
 
 # bad character :
 class Obj1(StorageObj):
@@ -78,7 +89,7 @@ class ParserHintsTest(unittest.TestCase):
         self.assertEqual(try_parser(Dict1), error)
 
     def test_missing_coma_dict(self):
-        error = "Error parsing the TypeSpec. Maybe you forgot a comma between the columns."
+        error = "Error parsing Type Specification. Trying to parse: 'b:intc:int'"
         self.assertEqual(try_parser(Dict2), error)
 
     def test_bad_characters_dict(self):
@@ -92,6 +103,14 @@ class ParserHintsTest(unittest.TestCase):
     def test_bad_format_dict(self):
         error = "The TypeSpec should have at least two '<' and two '>'. Format: @TypeSpec dict<<key:type>, value:type>."
         self.assertEqual(try_parser(Dict5), error)
+
+    def test_missing_name_attr(self):
+        error = "Error parsing Type Specification. Trying to parse: ':int'"
+        self.assertEqual(try_parser(Dict6), error)
+
+    def test_missing_type_attr(self):
+        error = "Error parsing Type Specification. Trying to parse: 'key:'"
+        self.assertEqual(try_parser(Dict7), error)
 
     def test_bad_colon_obj(self):
         error = "The ClassField @ClassField b:int should only have the character ':' if it is in a dict."

--- a/hecuba_py/tests/withcassandra/storagedict_tests.py
+++ b/hecuba_py/tests/withcassandra/storagedict_tests.py
@@ -147,6 +147,26 @@ class TestStorageDictRec2(StorageDict):
        @TypeSpec dict<<key:int>, mynumpy:numpy.ndarray,name:str,age:int,rec:tests.withcassandra.storagedict_tests.TestStorageObjNumpy>
     '''
 
+class TestStorageDictUnnamed(StorageDict):
+    '''
+       @TypeSpec dict<<int>, str>
+    '''
+
+class TestStorageDictUnnamed2(StorageDict):
+    '''
+       @TypeSpec dict<<key:int>, str>
+    '''
+
+class TestStorageDictUnnamed3(StorageDict):
+    '''
+       @TypeSpec dict<<int>, value:str>
+    '''
+
+class TestStorageDictUnnamed4(StorageDict):
+    '''
+       @TypeSpec dict<<int>, str,int>
+    '''
+
 class StorageDictTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -1373,6 +1393,34 @@ class StorageDictTest(unittest.TestCase):
         x = TestStorageDictRec1("test_sync")
         for i in range(0,3):
             self.assertTrue(myd[i].rec.mynumpy[0,0] == x[i].rec.mynumpy[0,0])
+
+    def test_unnamed(self):
+        myo = TestStorageDictUnnamed("test_unnamed")
+        myo[42] = "hola"
+        myo.sync()
+        myo = TestStorageDictUnnamed("test_unnamed")
+        self.assertTrue(myo[42] == "hola")
+
+    def test_unnamed2(self):
+        myo = TestStorageDictUnnamed2("test_unnamed2")
+        myo[42] = "hola"
+        myo.sync()
+        myo = TestStorageDictUnnamed2("test_unnamed2")
+        self.assertTrue(myo[42] == "hola")
+
+    def test_unnamed3(self):
+        myo = TestStorageDictUnnamed3("test_unnamed3")
+        myo[43] = "hola"
+        myo.sync()
+        myo = TestStorageDictUnnamed3("test_unnamed3")
+        self.assertTrue(myo[43] == "hola")
+
+    def test_unnamed4(self):
+        myo = TestStorageDictUnnamed4("test_unnamed4")
+        myo[42] = ["hola", 666]
+        myo.sync()
+        myo = TestStorageDictUnnamed4("test_unnamed4")
+        self.assertTrue(list(myo[42]), ["hola", 666])
 
 if __name__ == '__main__':
     unittest.main()

--- a/hecuba_py/tests/withcassandra/storageobj_tests.py
+++ b/hecuba_py/tests/withcassandra/storageobj_tests.py
@@ -110,6 +110,13 @@ class TestStorageObjNumpyDict(StorageObj):
     '''
     pass
 
+class TestStorageObjDict(StorageObj):
+    '''
+        @ClassField MyAttribute_1 int
+        @ClassField MyAttribute_2 dict <<int>, str>
+        @ClassField MyAttribute_3 dict <<int, str>, int>
+    '''
+
 
 class TestAttributes(StorageObj):
     '''
@@ -1397,6 +1404,14 @@ class StorageObjTest(unittest.TestCase):
         mynew_d = TestDateTime(self.current_ksp+".test_datetime")
         self.assertEqual(mynew_d.attr, dtime)
 
+    def test_storageobjdict_unnamed(self):
+        d = TestStorageObjDict("test_sobjdict_unnamed")
+        d.MyAttribute_2[1]="hola"
+        d.MyAttribute_3[[42,"hola"]]=666
+        d.sync()
+        d = TestStorageObjDict("test_sobjdict_unnamed")
+        self.assertEqual(d.MyAttribute_2[1], "hola")
+        self.assertEqual(d.MyAttribute_3[[42,"hola"]], 666)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION



        * Dictionary Parser did not support types and values WITHOUT names, even
          they were explained in the wiki.

        * Add support for unnamed types and values.

        * Add tests for unnamed dicts.

