### PR TITLE
Fix missing change in "Change UUID generation"

### DIFF
--- a/hecuba_core/src/ArrayDataStore.cpp
+++ b/hecuba_core/src/ArrayDataStore.cpp
@@ -252,7 +252,7 @@ void ArrayDataStore::update_metadata(const uint64_t *storage_id, ArrayMetadata *
 
 /* Generate a token for composite key (storage_id, cluster_id)
  * Args:
- *      storage_id: Points to a CassUuid
+ *      storage_id: Points to a UUID
  *      cluster_id: Contains a cluster_id
  * Returns an int64_t with the token that Cassandra assigns to the composite key
  */
@@ -268,22 +268,15 @@ int64_t murmur(const uint64_t *storage_id, const uint32_t cluster_id) {
             sidBE_low  = *(storage_id+1);
             cidBE =  cluster_id;
         } else {  // LittleEndian // --> Transform to BigEndian needed.
-            //Transform the fields from the cassandra 'CassUuid' type. Check also parse_uuid from HCache.cpp
-            uint32_t time_low = htobe32((*storage_id) & 0xFFFFFFFF);
-            uint16_t time_mid = htobe16(((*storage_id)>>32) & 0xFFFF);
-            uint16_t time_hi  = htobe16(((*storage_id)>>48));
-            sidBE_high        = (time_low | ((uint64_t) time_mid)<<32 | ((uint64_t)time_hi)<<48 );
-
-            uint64_t node     = htobe64((*(storage_id+1)) & 0xFFFFFFFFFFFF);
-            uint16_t clock    = htobe16((*(storage_id+1))>>48);
-            sidBE_low         = node | clock; //This works because 'node' has been translated to BigEndian
+            sidBE_high = *storage_id;
+            sidBE_low  = *(storage_id+1);
 
             cidBE = htobe32(cluster_id);
             sidlenBE = htobe16(sidlenBE);
             cidlenBE = htobe16(cidlenBE);
         }
         char* p = mykey;
-        memcpy(p, &sidlenBE, sizeof(sidlenBE)); // The 'CassUuid' type
+        memcpy(p, &sidlenBE, sizeof(sidlenBE));
         p+= sizeof(sidlenBE);
         memcpy(p, &sidBE_high, sizeof(sidBE_high));
         p+= sizeof(sidBE_high);

--- a/hecuba_py/tests/withcassandra/storagenumpy_tests.py
+++ b/hecuba_py/tests/withcassandra/storagenumpy_tests.py
@@ -1241,6 +1241,18 @@ class StorageNumpyTest(unittest.TestCase):
         t - 1   # Should not fail
         t-= 1   # Should not fail
 
+    def test_arrow_access(self):
+        n = np.arange(50*50).reshape(50,50)
+        s = StorageNumpy(n, "test_arrow_access")
+        s.sync()
+        del s
+        s = StorageNumpy(None, "test_arrow_access")
+        x = s[:, 20]
+        self.assertTrue(np.array_equal(x, n[:,20]))
+        y = s[:, 30]
+        self.assertTrue(np.array_equal(y, n[:,30]))
+        z = s[:, 49]
+        self.assertTrue(np.array_equal(z, n[:,49]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
    * After changing the UUID generation, it is always stored as an UUID
      format, and therefore follows the bigendian codification. The 'murmur'
      code was assuming a CassUuid, which is no longer the case.