### PR TITLE
Notify number of cassandra nodes up at starting

### DIFF
--- a/cassandra4slurm/scripts/job.sh
+++ b/cassandra4slurm/scripts/job.sh
@@ -206,7 +206,7 @@ echo "Checking..."
 RETRY_COUNTER=0
 get_nodes_up
 while [ "$NODE_COUNTER" != "$N_NODES" ] && [ $RETRY_COUNTER -lt $RETRY_MAX ]; do
-    echo "Retry #$RETRY_COUNTER"
+    echo "$NODE_COUNTER/$N_NODES nodes UP. Retry #$RETRY_COUNTER"
     echo "Checking..."
     sleep 5
     get_nodes_up

--- a/cassandra4slurm/storage_home/storage_init.sh
+++ b/cassandra4slurm/storage_home/storage_init.sh
@@ -312,7 +312,7 @@ echo "Checking..."
 RETRY_COUNTER=0
 get_nodes_up
 while [ "$NODE_COUNTER" != "$N_NODES" ] && [ $RETRY_COUNTER -lt $RETRY_MAX ]; do
-    echo "Retry #$RETRY_COUNTER"
+    echo "$NODE_COUNTER/$N_NODES nodes UP. Retry #$RETRY_COUNTER"
     echo "Checking..."
     sleep 5
     get_nodes_up


### PR DESCRIPTION
    * When cassandra is starting it waits to the requested number of cassandra
      nodes to be alive, and keeps waiting... but there is no information on
      the number of nodes currently up. This commit shows a message with the
      number of cassandra nodes up versus the requested.