### PR TITLE
Fix problem with copy_snapshot hanging

### DIFF
--- a/cassandra4slurm/scripts/copy_snapshot.sh
+++ b/cassandra4slurm/scripts/copy_snapshot.sh
@@ -33,19 +33,12 @@ cat $RINGFILE | grep -F $NODE_IP | awk '{print $NF }' | tr "\n" "," > $SNAP_DEST
 
 # Saving cluster name (to restore it properly)
 echo "$CLUSTER" > $SNAP_DEST/$SNAP_NAME-cluster.txt
-# For each folder in the data home, it is checked if the links to GPFS are already created, otherwise, create it
-for folder in $(ls $DATA_HOME)
-do
-    for subfolder in $(ls $DATA_HOME/$folder)
-    do
-        mkdir -p $SNAP_DEST/$folder/$subfolder/snapshots
-        if [ -d $DATA_HOME/$folder/$subfolder/snapshots/$SNAP_NAME ]
-        then
-            mv $DATA_HOME/$folder/$subfolder/snapshots/$SNAP_NAME $SNAP_DEST/$folder/$subfolder/snapshots/
-            ln -s $SNAP_DEST/$folder/$subfolder/snapshots/$SNAP_NAME $DATA_HOME/$folder/$subfolder/snapshots/$SNAP_NAME
-        fi
-    done
- done
+
+# copy snapshot directory to Destination directory
+pushd $DATA_HOME
+cp -Rf --parents */*/snapshots/$SNAP_NAME $SNAP_DEST/
+popd
+
 
 # If HECUBA_ARROW is enabled, copy the ARROW directory
 if [ ! -z $HECUBA_ARROW ]; then


### PR DESCRIPTION
    * The code to copy a snapshot to destination directory had a condition to
      wait for a directory that it never came up due to the table being
      'dropped'.
    * This commit simplifies the copy but just copying the snapshot directory
      (independent of the content)