### PR TITLE
bug: use TBB instead of TBB_FOUND in cmake

### DIFF
--- a/hecuba_core/CMakeLists.txt
+++ b/hecuba_core/CMakeLists.txt
@@ -256,7 +256,7 @@ endif ()
 
 
 
-if (NOT TBB_FOUND)
+if (NOT TBB)
     message("Downloading Intel TBB")
     unset(TBB)
     set(build_prefix tbb_prefix)


### PR DESCRIPTION
variable TBB_FOUND Is not defined, forcing download and  source-install of intel-tbb on every install. This commit sets variable to TBB. 