### PR TITLE
Fix a problem with missing '--prefix'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,11 +103,14 @@ def setup_packages():
         dist.parse_command_line()
 
         # Get prefix from either config file or command line
-        prefix = dist.get_option_dict('install')['prefix'][1]
-        print(' ==== PREFIX = {}'.format(prefix), flush=True)
-        copy_files_to_dir(glob.glob('build/include/*'), prefix + "/include")
-        copy_files_to_dir(glob.glob('build/include/hecuba/*'), prefix + "/include/hecuba")
-        copy_files_to_dir(glob.glob('build/lib/*'), prefix + "/lib")
+        try:
+            prefix = dist.get_option_dict('install')['prefix'][1]
+            print('  == --prefix {} used. Copy header files and libraries inside.'.format(prefix), flush=True)
+            copy_files_to_dir(glob.glob('build/include/*'), prefix + "/include")
+            copy_files_to_dir(glob.glob('build/include/hecuba/*'), prefix + "/include/hecuba")
+            copy_files_to_dir(glob.glob('build/lib/*'), prefix + "/lib")
+        except (KeyError):
+            pass
 
 
 


### PR DESCRIPTION
    * Commit d025cabc420e5ba039d7008c8fa0b672aefcdc9d add code to copy
      header files and libraries to the destination PREFIX directory
      used by --prefix PREFIX flag. Unfortunately, it breaks
      installation if the '--prefix' is missing. Just avoid the copy if
      this option is not present.