### PR TITLE
Add USE_ARROW compilation flag

### DIFF
--- a/hecuba_core/CMakeLists.txt
+++ b/hecuba_core/CMakeLists.txt
@@ -5,6 +5,8 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake) #folder with Fi
 
 set(CORE_SRC_DIR "${CMAKE_SOURCE_DIR}/src")
 
+option(USE_ARROW  "Enable ARROW support" FALSE)
+
 # CMAKE_BUILD_PARALLEL_LEVEL controls the level of parallelism, use it for Make also
 message(STATUS "===> CMAKE_BUILD_PARALLEL_LEVEL=$ENV{CMAKE_BUILD_PARALLEL_LEVEL}")
 if (NOT $ENV{CMAKE_BUILD_PARALLEL_LEVEL} STREQUAL "")
@@ -277,6 +279,7 @@ else ()
     set(ALL_LIBS ${ALL_LIBS} ${TBB})
 endif ()
 
+if (USE_ARROW)
 if (NOT ARROW)
     message("Downloading Apache ARROW")
     unset(ARROW) #to avoid name clash
@@ -311,6 +314,10 @@ else ()
     message(STATUS "Using system's ARROW " ${ARROW})
     set(ALL_LIBS ${ALL_LIBS} ${ARROW})
 endif ()
+add_compile_definitions(ARROW)    # Define ARROW preprocessor macro to enable arrow use
+else(USE_ARROW)
+    message(STATUS "ARROW (${ARROW}) is disabled by user!")
+endif(USE_ARROW)
 
 if (NOT YAML)
     message("Downloading YAML-CPP library")

--- a/hecuba_core/src/ArrayDataStore.cpp
+++ b/hecuba_core/src/ArrayDataStore.cpp
@@ -1,5 +1,6 @@
 #include "ArrayDataStore.h"
 
+#ifdef ARROW
 #include <arrow/memory_pool.h>
 #include <arrow/io/file.h>
 #include <arrow/status.h>
@@ -29,6 +30,7 @@
 #include <arrow/util/key_value_metadata.h>
 #include <arrow/array/builder_primitive.h>
 #include <arrow/array/builder_binary.h>
+#endif /* ARROW */
 
 #include <unistd.h>
 #include <sys/mman.h>
@@ -398,6 +400,7 @@ void ArrayDataStore::store_numpy_into_cas_as_arrow(const uint64_t *storage_id,
         std::cerr<< "store_numpy_into_cas_as_arrow called, but HECUBA_ARROW is not enabled" << std::endl;
         return;
     }
+#ifdef ARROW
 
     assert( metadata.dims.size() <= 2 ); // First version only supports 2 dimensions
 
@@ -503,6 +506,7 @@ void ArrayDataStore::store_numpy_into_cas_as_arrow(const uint64_t *storage_id,
 
         cache->put_crow( (void*)_keys, (void*)_values ); //Send column to cassandra
     }
+#endif /* ARROW  */
 }
 
 /***
@@ -517,6 +521,7 @@ void ArrayDataStore::store_numpy_into_cas_by_cols_as_arrow(const uint64_t *stora
                                                    std::vector<uint32_t> &cols) const {
 
     throw ModuleException("NOT IMPLEMENTED YET");
+#ifdef ARROW
 
     assert( metadata.dims.size() <= 2 ); // First version only supports 2 dimensions
 
@@ -619,6 +624,7 @@ void ArrayDataStore::store_numpy_into_cas_by_cols_as_arrow(const uint64_t *stora
         //cache_arrow_write->put_crow( (void*)_keys, (void*)_values ); //Send column to cassandra
         cache->put_crow( (void*)_keys, (void*)_values ); //Send column to cassandra
     }
+#endif /* ARROW */
 }
 
 /***
@@ -891,6 +897,7 @@ void ArrayDataStore::read_numpy_from_cas_by_coords(const uint64_t *storage_id, A
 
 }
 
+#ifdef ARROW
 /* Open an 'arrow_file_name' in a local environment.
  * It always succeed or raises exception
  */
@@ -1408,3 +1415,4 @@ void ArrayDataStore::read_numpy_from_cas_arrow(const uint64_t *storage_id, Array
     }
     close(fdIn);
 }
+#endif /* ARROW */

--- a/hecuba_core/src/ArrayDataStore.h
+++ b/hecuba_core/src/ArrayDataStore.h
@@ -42,7 +42,9 @@ public:
 
     //lgarrobe
     std::string TN  = "";
+#ifdef ARROW
     void read_numpy_from_cas_arrow(const uint64_t *storage_id, ArrayMetadata &metadata, std::vector<uint64_t> &cols, void *save);
+#endif /*ARROW*/
     void store_numpy_into_cas_as_arrow(const uint64_t *storage_id, ArrayMetadata &metadata,
                                        void *data) const;
     void store_numpy_into_cas_by_cols_as_arrow(const uint64_t *storage_id, ArrayMetadata &metadata, void *data, std::vector<uint32_t> &cols) const;
@@ -69,11 +71,13 @@ protected:
 
     std::shared_ptr<StorageInterface> storage; //StorageInterface* storage;
 private:
+#ifdef ARROW
     int open_arrow_file(std::string arrow_file_name) ;
     int find_and_open_arrow_file(const uint64_t * storage_id, const uint32_t cluster_id, const std::string arrow_file_name);
+    void *get_in_addr(struct sockaddr *sa);
+#endif /*ARROW*/
     std::set<uint32_t> loaded_cluster_ids;
 
-    void *get_in_addr(struct sockaddr *sa);
 };
 
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ def cmake_build():
     print("JOBS={}".format(jobs), flush=True)
     try:
         cmake_args=["cmake", "-H./hecuba_core", "-B./build"]
+        #cmake_args=cmake_args + ["-DUSE_ARROW=TRUE"]
         if c_binding_path:
             cmake_args=cmake_args + [ "-DC_BINDING_INSTALL_PREFIX={}".format(c_binding_path)]
             cmake_args=cmake_args + [ "-DPYTHON_VERSION=python{}.{}".format(sys.version_info.major, sys.version_info.minor)]


### PR DESCRIPTION
    * This allows the hecuba compilation without the arrow dependency.
    * By default it is disabled (USE_ARROW=FALSE).