### PR TITLE
Fix python installation for ARROW

### DIFF
--- a/hecuba_core/src/ArrayDataStore.cpp
+++ b/hecuba_core/src/ArrayDataStore.cpp
@@ -506,6 +506,8 @@ void ArrayDataStore::store_numpy_into_cas_as_arrow(const uint64_t *storage_id,
 
         cache->put_crow( (void*)_keys, (void*)_values ); //Send column to cassandra
     }
+#else /* ARROW */
+    throw ModuleException("ARROW DISABLED by user! Enable it using USE_ARROW=true flag");
 #endif /* ARROW  */
 }
 
@@ -1230,6 +1232,7 @@ int ArrayDataStore::find_and_open_arrow_file(const uint64_t * storage_id, const 
     }
     return open_arrow_file(local_path + arrow_file_name);
 }
+#endif /* ARROW */
 
 /***
  * Retrieve some Numpy columns from Cassandra in Arrow format into a numpy ndarray
@@ -1244,6 +1247,7 @@ void ArrayDataStore::read_numpy_from_cas_arrow(const uint64_t *storage_id, Array
         std::cerr<< "read_numpy_from_cas_arrow called, but HECUBA_ARROW is not enabled" << std::endl;
         return;
     }
+#ifdef ARROW
     std::shared_ptr<const std::vector<ColumnMeta> > keys_metas = read_cache->get_metadata()->get_keys();
     uint32_t keys_size = (*--keys_metas->end()).size + (*--keys_metas->end()).position;
     std::vector<const TupleRow *> result;
@@ -1414,5 +1418,7 @@ void ArrayDataStore::read_numpy_from_cas_arrow(const uint64_t *storage_id, Array
         close(fdIn);
     }
     close(fdIn);
-}
+#else /* ARROW */
+    throw ModuleException("ARROW DISABLED by user! Enable it using USE_ARROW=true flag");
 #endif /* ARROW */
+}

--- a/hecuba_core/src/ArrayDataStore.h
+++ b/hecuba_core/src/ArrayDataStore.h
@@ -42,9 +42,7 @@ public:
 
     //lgarrobe
     std::string TN  = "";
-#ifdef ARROW
     void read_numpy_from_cas_arrow(const uint64_t *storage_id, ArrayMetadata &metadata, std::vector<uint64_t> &cols, void *save);
-#endif /*ARROW*/
     void store_numpy_into_cas_as_arrow(const uint64_t *storage_id, ArrayMetadata &metadata,
                                        void *data) const;
     void store_numpy_into_cas_by_cols_as_arrow(const uint64_t *storage_id, ArrayMetadata &metadata, void *data, std::vector<uint32_t> &cols) const;


### PR DESCRIPTION
    * Python interface was using a method that has been disabled with
      USE_ARROW=false.

    * Add an exception to fail fast in case those disabled methods
      (read/store) were used.