### PR TITLE
Remove yaml dependency

### DIFF
--- a/hecuba_core/CMakeLists.txt
+++ b/hecuba_core/CMakeLists.txt
@@ -145,7 +145,6 @@ FIND_LIBRARY(CASS NAMES cassandra PATHS ${C_BINDING_INSTALL_PREFIX}/lib ENV LD_L
 FIND_LIBRARY(LIBUV NAMES uv PATHS ${C_BINDING_INSTALL_PREFIX}/lib ENV LD_LIBRARY_PATH)
 FIND_LIBRARY(TBB NAMES tbb PATHS ${C_BINDING_INSTALL_PREFIX}/lib ENV LD_LIBRARY_PATH)
 FIND_LIBRARY(ARROW NAMES arrow PATHS ${C_BINDING_INSTALL_PREFIX}/lib ENV LD_LIBRARY_PATH)
-FIND_LIBRARY(YAML NAMES yaml-cpp PATHS ${C_BINDING_INSTALL_PREFIX}/lib ENV LD_LIBRARY_PATH)
 #yolandab
 FIND_LIBRARY(KAFKA NAMES rdkafka PATHS ${C_BINDING_INSTALL_PREFIX}/lib ENV LD_LIBRARY_PATH)
 FIND_PROGRAM(KAFKATOOLS NAMES kafka-server-start.sh zookeeper-server-start.sh PATHS ${C_BINDING_INSTALL_PREFIX}/bin ENV PATH)
@@ -318,24 +317,6 @@ add_compile_definitions(ARROW)    # Define ARROW preprocessor macro to enable ar
 else(USE_ARROW)
     message(STATUS "ARROW (${ARROW}) is disabled by user!")
 endif(USE_ARROW)
-
-if (NOT YAML)
-    message("Downloading YAML-CPP library")
-    unset(YAML) #to avoid name clash
-    ExternalProject_Add(
-        YAML    #YAML-prefix
-        DOWNLOAD_DIR ${CMAKE_CURRENT_LIST_DIR}/dependencies
-        URL "https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.7.0.tar.gz"
-        URL_HASH SHA256=43e6a9fcb146ad871515f0d0873947e5d497a1c9c60c58cb102a97b47208b7c3
-        INSTALL_DIR ${C_BINDING_INSTALL_PREFIX}
-        CMAKE_ARGS ${CMAKE_SUBPROJECT_FLAGS} -DCMAKE_INSTALL_PREFIX=${C_BINDING_INSTALL_PREFIX} -DYAML_BUILD_SHARED_LIBS=ON
-    )
-    add_dependencies(hfetch YAML)
-    set(ALL_LIBS ${ALL_LIBS} ${C_BINDING_INSTALL_PREFIX}/lib/libyaml-cpp.so)
-else ()
-    message(STATUS "Using system's YAML " ${YAML})
-    set(ALL_LIBS ${ALL_LIBS} ${YAML})
-endif ()
 
 target_link_libraries(hfetch ${ALL_LIBS})
 


### PR DESCRIPTION
    * Library yaml-cpp is not needed anymore. It was used in the initial
      steps of the C++ interface.