### PR TITLE
Fix bug in IStorage::extractMultiValuesFromQueryResult

### DIFF
--- a/hecuba_core/src/api/IStorage.cpp
+++ b/hecuba_core/src/api/IStorage.cpp
@@ -348,7 +348,7 @@ void IStorage::extractMultiValuesFromQueryResult(void *query_result, void *value
     if (metas->size() == 1) {
         memcpy(valuetoreturn, valuetmp, attr_size);
     } else {
-        memcpy(valuetoreturn, &valuetmp, attr_size);
+        memcpy(valuetoreturn, &valuetmp, sizeof(char*));
     }
 }
 


### PR DESCRIPTION
    * When extracing multiple values from a Result query we used the
      last 'value' size instead of a pointer to the whole struct.