### PR TITLE
Fix a bug in IStorage::setCache

### DIFF
--- a/hecuba_core/src/api/IStorage.cpp
+++ b/hecuba_core/src/api/IStorage.cpp
@@ -582,8 +582,8 @@ std::shared_ptr<CacheTable> IStorage::getDataAccess() const {
 	return dataAccess;
 }
 
-void IStorage::setCache(const CacheTable& cache) {
-	dataAccess = std::make_shared<CacheTable>(cache);
+void IStorage::setCache(CacheTable& cache) {
+	dataAccess = std::shared_ptr<CacheTable>(&cache);
 	dataWriter = dataAccess->get_writer();
 }
 

--- a/hecuba_core/src/api/IStorage.h
+++ b/hecuba_core/src/api/IStorage.h
@@ -58,7 +58,7 @@ class IStorage {
         const std::string& getName() const;
 
         std::shared_ptr<CacheTable>getDataAccess()const ;
-        void setCache(const CacheTable &cache);
+        void setCache(CacheTable &cache);
 
         void sync(void);
 


### PR DESCRIPTION
    * The invocation of IStorage::setCache was invoking make_shared to
      generate a shared_ptr... which create a new instance of the object
      instead of just reusing the object.