### PR TITLE
Improve writer

### DIFF
--- a/hecuba_core/src/Writer.cpp
+++ b/hecuba_core/src/Writer.cpp
@@ -164,6 +164,11 @@ Writer::~Writer() {
         cass_prepared_free(this->prepared_query);
         prepared_query = NULL;
     }
+    for(auto it: prepared_partial_queries) {
+        cass_prepared_free(it.second);
+        it.second = nullptr;
+    }
+
     if (this->topic_name) {
         free(this->topic_name);
         this->topic_name = NULL;

--- a/hecuba_core/src/Writer.cpp
+++ b/hecuba_core/src/Writer.cpp
@@ -8,6 +8,7 @@
 /* Thread to process the pending data to be sent to cassandra */
 void Writer::async_query_thread_code() {
     while(!finish_async_query_thread) {
+#if 0
         while((ncallbacks < max_calls) && !data.empty()) {
             call_async();
         }
@@ -16,6 +17,10 @@ void Writer::async_query_thread_code() {
         } else { //Saturated... quick
             std::this_thread::yield();
         }
+#else
+        sempending_data->acquire(); // Wait for pending data
+        call_async();
+#endif
     }
 }
 
@@ -97,6 +102,8 @@ Writer::Writer(const TableMetadata *table_meta, CassSession *session,
     this->lazy_write_enabled = false; // Disabled by default, will be enabled on ArrayDataStore
     this->dirty_blocks = new tbb::concurrent_hash_map <const TupleRow *, const TupleRow *, Writer::HashCompare >();
     this->finish_async_query_thread = false;
+    sempending_data = new Semaphore(0);
+    semmaxcallbacks = new Semaphore(max_callbacks);
     this->async_query_thread = std::thread(&Writer::async_query_thread_code, this);
     this->topic_name = nullptr;
     this->topic = nullptr;
@@ -153,6 +160,7 @@ Writer& Writer::operator = (const Writer& src) {
 Writer::~Writer() {
     DBG( " WRITER: Destructor "<< ((topic_name!=nullptr)?topic_name:""));
     wait_writes_completion(); // WARNING! It is necessary to wait for ALL CALLBACKS to finish, because the 'data' structure required by the callback will dissapear with this destructor
+    sempending_data->release();// Unblock the async_query_thread (which does not have any work)
     auto async_query_thread_id = this->async_query_thread.get_id();
     this->finish_async_query_thread = true;
     this->async_query_thread.join();
@@ -178,6 +186,8 @@ Writer::~Writer() {
         rd_kafka_destroy(this->producer);
         this->producer = NULL;
     }
+    delete (this->sempending_data);
+    delete (this->semmaxcallbacks);
     delete (this->k_factory);
     delete (this->v_factory);
     delete (this->timestamp_gen);
@@ -362,6 +372,7 @@ void Writer::queue_async_query( const TupleRow *keys, const TupleRow *values) {
 
     //std::cout<< "  Writer::flushing item created pair"<<std::endl;
     data.push(item);
+    sempending_data->release(); //One more pending msg
 }
 
 void Writer::flush_dirty_blocks() {
@@ -407,6 +418,7 @@ void Writer::callback(CassFuture *future, void *ptr) {
     void **data = reinterpret_cast<void **>(ptr);
     assert(data != NULL && data[0] != NULL);
     Writer *W = (Writer *) data[0];
+    W->semmaxcallbacks->release(); // Limit number of callbacks
 
     //std::cout<< "Writer::callback"<< std::endl;
     CassError rc = cass_future_error_code(future);
@@ -451,6 +463,8 @@ void Writer::async_query_execute(const TupleRow *keys, const TupleRow *values) {
     if (!this->disable_timestamps) {
         cass_statement_set_timestamp(statement, keys->get_timestamp());
     }
+
+    semmaxcallbacks->acquire(); // Limit number of callbacks
 
     CassFuture *query_future = cass_session_execute(session, statement);
     cass_statement_free(statement);

--- a/hecuba_core/src/Writer.h
+++ b/hecuba_core/src/Writer.h
@@ -106,8 +106,6 @@ private:
     void async_query_execute(const TupleRow *keys, const TupleRow *values);
     void queue_async_query( const TupleRow *keys, const TupleRow *values);
     static void callback(CassFuture *future, void *ptr);
-    std::mutex async_query_thread_lock;
-    bool async_query_thread_created;
     void async_query_thread_code();
     bool finish_async_query_thread;
     std::thread async_query_thread;

--- a/hecuba_core/src/Writer.h
+++ b/hecuba_core/src/Writer.h
@@ -15,6 +15,7 @@
 
 #include "TimestampGenerator.h"
 #include "TupleRowFactory.h"
+#include "Semaphore.h"
 
 
 class Writer {
@@ -95,6 +96,8 @@ private:
 
     uint32_t max_calls;
     std::atomic<uint32_t> ncallbacks;
+    Semaphore* sempending_data;  // Synchronization semaphore to wait for new elements in 'data'
+    Semaphore* semmaxcallbacks; //Resource limiting Semaphore to limit the number of in_flight callbacks.
     std::atomic<uint32_t> error_count;
     const TableMetadata *table_metadata = nullptr;
 


### PR DESCRIPTION
  *    Substitute sleeps by semaphores

  * Move writer thread creation to constructor.
     * A writing thread was created in Writer the first time a write
          operation was issued. Move that code to the constructor.

  * Missing part in prepared_partial_queries



