### PR TITLE
Changed behaviour for Py_BuildValue

### DIFF
--- a/hecuba_core/src/py_interface/NumpyStorage.h
+++ b/hecuba_core/src/py_interface/NumpyStorage.h
@@ -3,6 +3,7 @@
 
 #include "../ArrayDataStore.h"
 #include "../MetaManager.h"
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <climits>
 

--- a/hecuba_core/src/py_interface/PythonParser.h
+++ b/hecuba_core/src/py_interface/PythonParser.h
@@ -1,6 +1,7 @@
 #ifndef PYTHON_PARSER_H
 #define PYTHON_PARSER_H
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #include <string>

--- a/hecuba_core/src/py_interface/UnitParser.h
+++ b/hecuba_core/src/py_interface/UnitParser.h
@@ -1,6 +1,7 @@
 #ifndef HFETCH_UNITPARSER_H
 #define HFETCH_UNITPARSER_H
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #include <cassert>


### PR DESCRIPTION
    * From Python 3.9 and older PY_SSIZE_T_CLEAN must be defined before
      including Python.h, otherwise Py_BuildValue interprets Py_syze_t
      as an int (which has "surprising" results).