### PR TITLE
Allow to configure number of cores fo application and cassandra

### DIFF
--- a/cassandra4slurm/scripts/app_node.sh
+++ b/cassandra4slurm/scripts/app_node.sh
@@ -33,5 +33,5 @@ fi
 
 
 echo "Launching application: $APP_PATH"
-eval $APP_PATH
+srun --overlap --mem=0 $APP_PATH
 echo "[INFO] The application execution has stopped in node $(hostname)"

--- a/cassandra4slurm/scripts/hecuba_environment.template
+++ b/cassandra4slurm/scripts/hecuba_environment.template
@@ -22,3 +22,11 @@
 #export WRITE_BUFFER_SIZE=1000
 #export WRITE_CALLBACKS_NUMBER=16
 
+# Use a single table to store all StorageNumpys
+#export HECUBA_SN_SINGLE_TABLE=False
+
+# Configure number of cores to use for the application
+#export C4S_APP_CORES=1
+# Configure number of cores to use for cassandra
+#export C4S_CASSANDRA_CORES=1
+

--- a/cassandra4slurm/scripts/job.sh
+++ b/cassandra4slurm/scripts/job.sh
@@ -70,10 +70,12 @@ if [ "X$HECUBA_ARROW" != "X" ]; then
     echo "export HECUBA_ARROW_PATH=$ROOT_PATH/" >> $ENVFILE
 fi
 
-if [ "$DISJOINT" == "1" ]; then
-    C4S_CASSANDRA_CORES=$(nproc --all)
-else
-    C4S_CASSANDRA_CORES=4
+if [ "X$C4S_CASSANDRA_CORES" == "X" ]; then
+    if [ "$DISJOINT" == "1" ]; then
+        C4S_CASSANDRA_CORES=$(nproc --all)
+    else
+        C4S_CASSANDRA_CORES=4
+    fi
 fi
 
 RETRY_MAX=3000 # This value is around 50, higher now to test big clusters that need more time to be completely discovered
@@ -257,11 +259,13 @@ cp $CASSFILE $CASSFILETOSYNC
 # Application launcher
 if [ "$APP_NODES" != "0" ]; then
     APP_AND_PARAMS=$(cat $APPPATHFILE)
-    if [ "$DISJOINT" == "1" ]; then
-        # TODO: is this required??? --> export PYCOMPSS_NODES=$(cat $APPFILE | tr '\n' ',' | sed "s/,/$full_iface,/g" | rev | cut -c 2- | rev) # Workaround for disjoint executions with PyCOMPSs
-        C4S_APP_CORES=$(nproc --all)
-    else
-        C4S_APP_CORES=$(( $(nproc --all) - $C4S_CASSANDRA_CORES ))
+    if [ "X$C4S_APP_CORES" == X ]; then
+        if [ "$DISJOINT" == "1" ]; then
+            # TODO: is this required??? --> export PYCOMPSS_NODES=$(cat $APPFILE | tr '\n' ',' | sed "s/,/$full_iface,/g" | rev | cut -c 2- | rev) # Workaround for disjoint executions with PyCOMPSs
+            C4S_APP_CORES=$(nproc --all)
+        else
+            C4S_APP_CORES=$(( $(nproc --all) - $C4S_CASSANDRA_CORES ))
+        fi
     fi
     if [ "$PYCOMPSS_APP" == "1" ]; then
         PYCOMPSS_FLAGS=$(cat $PYCOMPSS_FLAGS_FILE)


### PR DESCRIPTION
    * Add C4S_APP_CORES and C4S_CASSANDRA_CORES variables to define the cores
      to use when launching application and Cassandra.
    * By default these variables default to the total number of cores of the
      machine for the application minus the cores used for Cassandra (4).