### PR TITLE
Fix bug when disconnecting Cassandra

### DIFF
--- a/hecuba_core/src/StorageInterface.cpp
+++ b/hecuba_core/src/StorageInterface.cpp
@@ -72,6 +72,8 @@ StorageInterface::~StorageInterface() {
 int StorageInterface::disconnectCassandra() {
     if (session != NULL) {
         CassFuture *close_future = cass_session_close(session);
+        CassError rc = cass_future_error_code(close_future);
+        CHECK_CASS("StorageInterface::disconnectCassandra Failed");
         cass_future_free(close_future);
         cass_session_free(session);
         cass_cluster_free(cluster);

--- a/hecuba_core/src/api/HecubaSession.cpp
+++ b/hecuba_core/src/api/HecubaSession.cpp
@@ -373,11 +373,19 @@ HecubaSession::~HecubaSession() {
     for (std::list<std::shared_ptr<CacheTable>>::iterator it = alive_objects.begin(); it != alive_objects.end();) {
         std::shared_ptr<CacheTable> t = *it;
         //std::cout << "LIST DEL: "<< t.get() <<" ("<<t.use_count()<<")"<<std::endl;
+        if (t.use_count()>2) {
+            t.get()->get_writer()->wait_writes_completion();
+            DBG( "  LIST DEL AFTER: "<< t.get() <<" ("<<t.use_count()<<")");
+        }
         it = alive_objects.erase(it); // this will block waiting for the 'sync'
     }
     for (std::list<std::shared_ptr<ArrayDataStore>>::iterator it = alive_numpy_objects.begin(); it != alive_numpy_objects.end();) {
         std::shared_ptr<ArrayDataStore> t = *it;
-        //std::cout << "LIST DEL: "<< t.get() <<" ("<<t.use_count()<<")"<<std::endl;
+        //std::cout << "LIST DEL ARRAY: "<< t.get() <<" ("<<t.use_count()<<")"<<std::endl;
+        if (t.use_count()>2) {
+            t.get()->getWriteCache()->get_writer()->wait_writes_completion();
+            DBG( "  LIST DEL AFTER: "<< t.get() <<" ("<<t.use_count()<<")");
+        }
         it = alive_numpy_objects.erase(it); // this will block waiting for the 'sync'
     }
 }


### PR DESCRIPTION
    * After finishing the HecubaSession and disconnecting Cassandra session, we
      were NOT waiting for the correct finalization of it, and therefore, the
      Cassandra driver failed with a 'pure virtual method called'.
    * Waiting for the succesful finalization of the cassandra driver just make it work.
    * Added an extra check when finishing the HecubaSession to wait for any
      object with a number of references greater thatn 2.