### PR TITLE
move hecuba istorage cachetable to storage interface

### DIFF
--- a/hecuba_core/src/ArrayDataStore.cpp
+++ b/hecuba_core/src/ArrayDataStore.cpp
@@ -83,9 +83,10 @@ CacheTable* ArrayDataStore::getStaticHecubaIstorageCacheTable(const char *table_
     return &metadata_cache;
 }
 
-ArrayDataStore::ArrayDataStore(const char *table, const char *keyspace, CassSession *session,
+ArrayDataStore::ArrayDataStore(const char *table, const char *keyspace, std::shared_ptr<StorageInterface> storage,
                                std::map<std::string, std::string> &config) {
-
+    this->storage = storage;
+    CassSession* session = storage->get_session();
     char * env_path = std::getenv("HECUBA_ARROW");
     if (env_path != nullptr) {
         std::string hecuba_arrow(env_path);
@@ -195,38 +196,9 @@ ArrayDataStore::ArrayDataStore(const char *table, const char *keyspace, CassSess
     }
 
     //Metadata needed only for *reading* numpy metas from hecuba.istorage
-    //lgarrobe
-    std::vector<std::map<std::string, std::string> > metadata_keys = {{{"name", "storage_id"}}};
-
-    std::vector<std::map<std::string, std::string> > metadata_columns = {{{"name", "base_numpy"}}
-									,{{"name", "class_name"}}
-									,{{"name", "name"}}
-									,{{"name", "numpy_meta"}}};
-
-#if 0
-    TableMetadata *metadata_table_meta = new TableMetadata("istorage", "hecuba", metadata_keys, metadata_columns, session);
-
-    this->metadata_cache = new CacheTable(metadata_table_meta, session, config);
-
-
-    std::vector<std::map<std::string, std::string>> read_metadata_keys  (metadata_keys.begin(), (metadata_keys.end() ));
-    std::vector<std::map<std::string, std::string>> read_metadata_columns = metadata_columns;
-
-    metadata_table_meta = new TableMetadata("istorage", "hecuba", read_metadata_keys, read_metadata_columns, session);
-
-    this->metadata_read_cache = new CacheTable(metadata_table_meta, session, config);
-#else
-
-    this->metadata_cache = ArrayDataStore::getStaticHecubaIstorageCacheTable("istorage", "hecuba", metadata_keys, metadata_columns, session, config);
+    this->metadata_cache = storage->get_static_metadata_cache(config);
     this->metadata_read_cache = this->metadata_cache;
-#endif
 
-}
-
-ArrayDataStore::ArrayDataStore(const char *table, const char *keyspace, std::shared_ptr<StorageInterface> storage,
-                               std::map<std::string, std::string> &config) :
-    ArrayDataStore(table, keyspace, storage->get_session(), config) {
-    this->storage = storage;
 }
 
 ArrayDataStore::ArrayDataStore(const ArrayDataStore& src) {
@@ -237,13 +209,19 @@ ArrayDataStore& ArrayDataStore::operator= (const ArrayDataStore& src) {
 
     if (this != &src) {
         TN  = src.TN;
-        if (cache != nullptr) { delete (cache); }
-        cache = new CacheTable(*src.cache);
+        if (cache != nullptr) {
+            if ( cache->can_table_meta_be_freed() ) { // TODO FIX THIS THING
+                delete (this->cache);
+            }
+        }
+        if (src.cache->can_table_meta_be_freed()) { // TODO FIX THIS THING
+            cache = new CacheTable(*src.cache);
+        } else {
+            cache = src.cache;
+        }
         read_cache = cache;
-        if (metadata_cache!=nullptr) { delete (metadata_cache); }
-        metadata_cache = new CacheTable(*src.metadata_cache);
-        if (metadata_read_cache!=nullptr) { delete (metadata_read_cache); }
-        metadata_read_cache = new CacheTable(*src.metadata_read_cache);
+        metadata_cache      = src.metadata_cache;
+        metadata_read_cache = src.metadata_read_cache;
         partitioner         = src.partitioner; // uses default copy assignment
         arrow_enabled       = src.arrow_enabled;
         arrow_optane        = src.arrow_optane;
@@ -263,9 +241,6 @@ ArrayDataStore::~ArrayDataStore() {
         this->cache = nullptr;
     }
     if (this->metadata_cache){
-        if ( this->metadata_cache->can_table_meta_be_freed() ) { // TODO FIX THIS THING
-            delete (this->metadata_cache);
-        }
         this->metadata_cache = nullptr;
     }
     if (this->metadata_read_cache){

--- a/hecuba_core/src/ArrayDataStore.h
+++ b/hecuba_core/src/ArrayDataStore.h
@@ -14,8 +14,6 @@ class ArrayDataStore {
 
 public:
 
-    ArrayDataStore(const char *table, const char *keyspace, CassSession *session,
-                   std::map<std::string, std::string> &config);
     ArrayDataStore(const char *table, const char *keyspace, std::shared_ptr<StorageInterface> storage,
                    std::map<std::string, std::string> &config);
 

--- a/hecuba_core/src/StorageInterface.cpp
+++ b/hecuba_core/src/StorageInterface.cpp
@@ -99,6 +99,20 @@ CacheTable *StorageInterface::make_cache(const char *table, const char *keyspace
     return new CacheTable(table_meta, session, config);
 }
 
+CacheTable *StorageInterface::get_static_metadata_cache( config_map &config) {
+    std::vector<std::map<std::string, std::string> > metadata_keys = {{{"name", "storage_id"}}};
+
+    std::vector<std::map<std::string, std::string> > metadata_columns = {{{"name", "base_numpy"}}
+									,{{"name", "class_name"}}
+									,{{"name", "name"}}
+									,{{"name", "numpy_meta"}}};
+
+    if (!session) throw ModuleException("StorageInterface not connected to any node");
+    static TableMetadata table_meta ("istorage", "hecuba", metadata_keys, metadata_columns, session);
+    static CacheTable staticCacheTable (&table_meta, session, config, false);
+    return &staticCacheTable;
+}
+
 
 Writer *StorageInterface::make_writer(const char *table, const char *keyspace,
                                       std::vector<config_map> &keys_names,

--- a/hecuba_core/src/StorageInterface.h
+++ b/hecuba_core/src/StorageInterface.h
@@ -43,6 +43,9 @@ public:
                            std::vector<config_map> &columns_names,
                            config_map &config);
 
+    CacheTable *get_static_metadata_cache(config_map &config);
+
+
     Writer *make_writer(const char *table, const char *keyspace,
                         std::vector<config_map> &keys_names,
                         std::vector<config_map> &columns_names,

--- a/hecuba_core/src/api/HecubaSession.cpp
+++ b/hecuba_core/src/api/HecubaSession.cpp
@@ -344,22 +344,7 @@ HecubaSession::HecubaSession() {
 // TODO: extend writer to support lists
 
 
-std::vector<config_map> pkeystypes_n = { {{"name", "storage_id"}} };
-std::vector<config_map> ckeystypes_n = {};
-std::vector<config_map> colstypes_n = {
-						{{"name", "base_numpy"}},
-                        {{"name", "class_name"}},
-						{{"name", "name"}},
-						{{"name", "numpy_meta"}},
-						//{{"name", "block_id"}}, //NOT USED
-						//{{"name", "view_serialization"}},  //Used by Python, uses pickle format. Let it be NULL and initialized at python code
-};
-						// TODO: extend writer to support lists {{"name", "tokens"}} }; //list
-
-// The attributes stored in istorage for all numpys are the same, we use a single writer for the session
-numpyMetaAccess = storageInterface->make_cache("istorage", "hecuba",
-												pkeystypes_n, colstypes_n,
-												config);
+numpyMetaAccess = storageInterface->get_static_metadata_cache(config);
 numpyMetaWriter = numpyMetaAccess->get_writer();
 
     //std::cout << " Constructor HecubaSession  id="<< std::this_thread::get_id()<<std::endl;
@@ -368,7 +353,9 @@ numpyMetaWriter = numpyMetaAccess->get_writer();
 }
 
 HecubaSession::~HecubaSession() {
-    delete(numpyMetaAccess);
+    if (numpyMetaAccess->can_table_meta_be_freed()) { // TODO FIX THIS THING
+        delete(numpyMetaAccess);
+    }
 
     for (std::list<std::shared_ptr<CacheTable>>::iterator it = alive_objects.begin(); it != alive_objects.end();) {
         std::shared_ptr<CacheTable> t = *it;

--- a/hecuba_core/src/api/StorageNumpy.h
+++ b/hecuba_core/src/api/StorageNumpy.h
@@ -144,7 +144,7 @@ class StorageNumpy:virtual public IStorage {
             // StorageNumpy
             this->arrayStore = std::make_shared<ArrayDataStore> (getTableName().c_str(),
                     getCurrentSession().config["execution_name"].c_str(),
-                    getCurrentSession().getStorageInterface()->get_session(), getCurrentSession().config);
+                    getCurrentSession().getStorageInterface(), getCurrentSession().config);
 
             getCurrentSession().registerObject(arrayStore,getClassName());
         }


### PR DESCRIPTION
    * The access to the hecuba.istorage table is required from other types of
      objects (not just StorageNumpys), therefore move it to the
      StorageInterface which is visible from C++ and Python.