### PR TITLE
Add cassandra connection as soon as possible

### DIFF
--- a/hecuba_core/src/api/IStorage.cpp
+++ b/hecuba_core/src/api/IStorage.cpp
@@ -12,6 +12,12 @@
 IStorage::IStorage() {
     HecubaExtrae_event(HECUBAEV, HECUBA_IS|HECUBA_INSTANTIATION);
     DBG( "default constructor this "<< this );
+    try {
+        // Start cassandra connection as soon as possible to speedup the global startup (removing the cassandra connection from the critical path)
+	    HecubaSession& currentSession = getCurrentSession();
+    } catch (ModuleException &e) {
+        // Cassandra is not up yet... continuing with volatile objects...
+    }
     HecubaExtrae_event(HECUBAEV, HECUBA_END);
 }
 


### PR DESCRIPTION
    * Connection to Cassandra takes a big amount of time, therefore it makes
      sense to try the connection as soon as possible (even if you will not use
      it due to just using volatile objects). In case the connection is not
      possible (because the cassandra cluster is not started yet), then it just
      silently continues... until a make_persistent, get_by_alias, ... is issued,
      and then it will retry the connection (but loosing any performance gain...)
      [this case, where you want you use persistent objects but Cassandra cluster
      is not yet started... is really strange and should not be the usual case]