### PR TITLE
Add 'wait_writes_completion' to HecubaSession

### DIFF
--- a/hecuba_core/src/api/HecubaSession.h
+++ b/hecuba_core/src/api/HecubaSession.h
@@ -28,6 +28,7 @@ public:
     bool registerObject(const std::shared_ptr<CacheTable> c, const std::string& class_name) ;
     bool registerObject(const std::shared_ptr<ArrayDataStore> a, const std::string& class_name) ;
     bool registerClassName(const std::string& class_name);
+    int wait_writes_completion(); /* Wait for the finalization of any pending write operation */
 private:
 
     std::mutex mxalive_objects;


### PR DESCRIPTION
    * Function to ensure all pending writes in a session have been acknowledged
      by Cassandra.

    * Added for testing purposes (not really needed as this is done
      automatically at the finalization of the applications).