### PR TITLE
Fix enqueue_cass_node with a hostname with dots

### DIFF
--- a/cassandra4slurm/enqueue_cass_node.sh
+++ b/cassandra4slurm/enqueue_cass_node.sh
@@ -39,7 +39,8 @@ if [ "$(cat $C4S_HOME/casslist-"$UNIQ_ID".txt | grep $(hostname))" != "" ]; then
     DBG " JAVA_HOME="$JAVA_HOME
     DBG " Cassandra node $(hostname) is starting now..."
     DBG " CASS_HOME="$CASS_HOME
-    $CASS_HOME/bin/cassandra -Dcassandra.consistent.rangemovement=false -Dcassandra.config=file://$C4S_HOME/conf/${UNIQ_ID}/cassandra-$(hostname).yaml -f | awk "{ print  $(hostname),\$0 }"
+    # Launch cassandra and prefix the output with 'hostname'
+    $CASS_HOME/bin/cassandra -Dcassandra.consistent.rangemovement=false -Dcassandra.config=file://$C4S_HOME/conf/${UNIQ_ID}/cassandra-$(hostname).yaml -f | awk "{ print  \"$(hostname)\",\$0 }"
     echo "Cassandra has stopped in node $(hostname)"
 else
     echo "Node $(hostname) is not part of the Cassandra node list."


### PR DESCRIPTION
    * If the hostname has a dot ('.') then awk complains. Use quotes to
      avoid the problem.