### PR TITLE
Fix IP command

### DIFF
--- a/cassandra4slurm/scripts/hecuba_debug.sh
+++ b/cassandra4slurm/scripts/hecuba_debug.sh
@@ -51,7 +51,8 @@ get_first_node() {
 function get_node_ip() {
     local node="$1"
     local iface="$2"
-    local IP=$(ssh $node "ip --brief address show dev $iface"| awk '{print $3}') #192.168.1.1/25
+    local IPCMD=$(which ip) # Some 'ssh' clients may loose the PATH, therefore assume that it will be at the same place...
+    local IP=$(ssh $node "$IPCMD --brief address show dev $iface"| awk '{print $3}') #192.168.1.1/25
     echo ${IP%/*} #Remove the last slashed content
 }
 


### PR DESCRIPTION
    * When connecting to a machine through SSH, the PATH variable may be lost
      and the binary for the ip command may not be found. So we try to use the
      same path as in the current hostname (in the hope that both machines will
      share the installation).