### PR TITLE
Fix launch_kafka.sh script

### DIFF
--- a/cassandra4slurm/scripts/job.sh
+++ b/cassandra4slurm/scripts/job.sh
@@ -281,7 +281,7 @@ sleep 5
 if [ "X$STREAMING" != "X" ]; then
     if [ ${STREAMING,,} == "true" ]; then
         source $HECUBA_ROOT/bin/cassandra4slurm/launch_kafka.sh
-        launch_kafka $CASSANDRA_NODELIST $UNIQ_ID $N_NODES
+        launch_kafka $CASSFILE $UNIQ_ID $N_NODES
     fi
 fi
 

--- a/cassandra4slurm/scripts/launch_kafka.sh
+++ b/cassandra4slurm/scripts/launch_kafka.sh
@@ -39,12 +39,13 @@ get_kafka_path () {
 }
 
 launch_kafka () {
-    local CASSANDRA_NODELIST="$1"
+    local CASSFILE="$1"
     local UNIQ_ID="$2"
     local N_NODES="$3"
 
-    local ZKNODE=$( get_first_node $CASSANDRA_NODELIST )
-    local ZKNODEIP=$( get_first_node $CASSANDRA_NODELIST.ips )
+    local ZKNODE=$( head -n 1 $CASSFILE )
+    local ZKNODEIP=$( head -n 1 $CASSFILE.ips )
+    local CASSANDRA_NODELIST=$(cat $CASSFILE | sed -e 's+ +,+g')
 
     KAFKA_PATH=$(get_kafka_path)
 


### PR DESCRIPTION
    * 'lauch_kafka.sh' requires a list of nodes suitable for SLURM and also
      their IP address to adapt the kafka configuration scripts, but it was
      receiving the list of nodes instead of the file name with both.