### PR TITLE
Improve StorageNumpy creation

### DIFF
--- a/hecuba_core/src/api/IStorage.h
+++ b/hecuba_core/src/api/IStorage.h
@@ -99,6 +99,8 @@ class IStorage {
         bool pending_to_persist = false;
         bool persistent = false;
 
+        virtual bool is_create_table_required() {return true;}; // Does the object requires to create a table at each instantiation?
+
         enum valid_writes {
             SETATTR_TYPE,
             SETITEM_TYPE,

--- a/hecuba_core/src/api/StorageNumpy.h
+++ b/hecuba_core/src/api/StorageNumpy.h
@@ -376,6 +376,14 @@ class StorageNumpy:virtual public IStorage {
             };
 
         }
+
+        bool is_create_table_required(void) {
+            // If a single table is used, then it is NOT required to create a
+            // table at each instantiation (just the first time, which is done
+            // at initialization time))
+            static bool current_table_required = (getCurrentSession().config["hecuba_sn_single_table"] == "false");
+            return current_table_required;
+        }
     
 };
 


### PR DESCRIPTION
    * When instantiating StorageNumpys we require a new table per StorageNumpy,
      unless HECUBA_SN_SINGLE_TABLE is used, and therefore only one table is
      required, which is created during the initialization time.

    * Implement a generic version as this will also be required for StorageObjects.