### PR TITLE
Fix streaming numpys

### DIFF
--- a/hecuba_core/src/CacheTable.h
+++ b/hecuba_core/src/CacheTable.h
@@ -39,8 +39,8 @@ public:
     std::vector<const TupleRow *> retrieve_from_cassandra(const TupleRow *keys, const char* attr_name=NULL );
 
     void put_crow(const TupleRow *keys, const TupleRow *values);
-    void send_event(const TupleRow *keys, const TupleRow *values);
-    void close_stream();
+    void send_event(const char* topic_name, const TupleRow *keys, const TupleRow *values);
+    void close_stream(const char *topic_name);
 
     void delete_crow(const TupleRow *keys);
 
@@ -58,11 +58,11 @@ public:
     Writer * get_writer();
 
     /*** Stream operations ***/
-    void  enable_stream(const char * topic_name, std::map<std::string, std::string> &config);
-    void  enable_stream_producer(void);
-    void  enable_stream_consumer(void);
-    void poll(char *data, const uint64_t size);
-    std::vector<const TupleRow *>  poll(void);
+    void  enable_stream(std::map<std::string, std::string> &config);
+    void  enable_stream_producer(const char* topic_name);
+    void  enable_stream_consumer(const char* topic_name);
+    void poll(const char * topic_name, char *data, const uint64_t size);
+    std::vector<const TupleRow *>  poll(const char* topic_name);
 
     /*** Auxiliary methods ***/
     const TupleRow* get_new_keys_tuplerow(void* keys) const;
@@ -72,7 +72,7 @@ public:
         return should_table_meta_be_freed;
     }
 private:
-    rd_kafka_message_t * kafka_poll(void) ;
+    rd_kafka_message_t * kafka_poll(const char* topic_name) ;
 
 
     /* CASSANDRA INFORMATION FOR RETRIEVING DATA */
@@ -93,10 +93,9 @@ private:
 
     Writer *writer = nullptr;
     /*** Stream information ***/
-    char * topic_name = nullptr;
     std::map<std::string, std::string> stream_config;
     rd_kafka_conf_t *kafka_conf = nullptr;
-    rd_kafka_t *consumer = nullptr;
+    std::map<std::string, rd_kafka_t*> kafkaConsumer; // [topic_name, consumer]
     bool should_table_meta_be_freed = false; //For cases where table_metadata is a static variable instead of a 'new' (numpys)
 };
 

--- a/hecuba_core/src/Writer.h
+++ b/hecuba_core/src/Writer.h
@@ -36,12 +36,11 @@ public:
 
     void enable_stream(const char* topic_name, std::map<std::string,std::string>  &config);
 
-    rd_kafka_conf_t *create_stream_conf(std::map<std::string,std::string>  &config);
 
 
-    void send_event(char* event, const uint64_t size);
-    void send_event(const TupleRow* key,const TupleRow *value);
-    void send_event(void* key, void* value);
+    void send_event(const char* topic_name, char* event, const uint64_t size);
+    void send_event(const char* topic_name, const TupleRow* key,const TupleRow *value);
+    void send_event(const char* topic_name, void* key, void* value);
 
     // Overload 'write_to_casandra' to write a single column (instead of all the columns)
     void write_to_cassandra(void *keys, void *values , const char *value_name);
@@ -105,10 +104,12 @@ private:
     void flush_dirty_blocks();
     void queue_async_query(const TupleRow* keys, const TupleRow* values);
 
+    rd_kafka_conf_t *create_stream_conf(std::map<std::string,std::string>  &config);
+    void deleteKafkaProducer(void); // Delete Kafka attributes 'producer' and 'kafkaTopics'
+
     // StorageStream attributes
-    char * topic_name = nullptr;
-    rd_kafka_topic_t *topic = nullptr;
     rd_kafka_t *producer = nullptr;
+    std::map<std::string, rd_kafka_topic_t*> kafkaTopics; // [topic_name, topic]
 
     std::map<std::string, std::string>* myconfig; // A reference to config, I would like to be a reference to the WriterThread, but this causes a double reference Writer<->WriterThread, this avoids the reference by forcing a call to the static method WriterThread.get(myconfig).
 };

--- a/hecuba_core/src/api/StorageDict.h
+++ b/hecuba_core/src/api/StorageDict.h
@@ -213,7 +213,7 @@ class StorageDict:virtual public IStorage {
             const TupleRow* trow_values = this->getDataAccess()->get_new_values_tuplerow(cc_val);
 #if 1
             if (this->isStream()) {
-                this->getDataWriter()->send_event(trow_key, trow_values); // stream value (storage_id/value)
+                this->getDataWriter()->send_event(UUID::UUID2str(getStorageID()), trow_key, trow_values); // stream value (storage_id/value)
                 send_values(value); // If value is an IStorage type stream its contents also
             }
 #endif

--- a/hecuba_core/src/api/StorageNumpy.h
+++ b/hecuba_core/src/api/StorageNumpy.h
@@ -212,7 +212,7 @@ class StorageNumpy:virtual public IStorage {
 
         void send(void) {
             DBG("DEBUG: IStorage::send: sending numpy. Size "<< numpy_metas.get_array_size());
-            getDataWriter()->send_event((char *) data, numpy_metas.get_array_size());
+            getDataWriter()->send_event(UUID::UUID2str(getStorageID()), (char *) data, numpy_metas.get_array_size());
         }
 
         void writePythonSpec() {} // StorageNumpy do not have python specification

--- a/hecuba_core/src/py_interface/NumpyStorage.cpp
+++ b/hecuba_core/src/py_interface/NumpyStorage.cpp
@@ -138,7 +138,7 @@ PyObject *NumpyStorage::get_row_elements(const uint64_t *storage_id, ArrayMetada
     return Py_BuildValue("i", row_elements);
 }
 
-void NumpyStorage::send_event(ArrayMetadata &np_metas, PyArrayObject *numpy, PyObject* coord) {
+void NumpyStorage::send_event(const char* topic_name, ArrayMetadata &np_metas, PyArrayObject *numpy, PyObject* coord) {
     void *data = PyArray_DATA(numpy);
 	if (coord != Py_None) {
         throw ModuleException("Sending specific numpy blocks is NOT IMPLEMENTED");
@@ -149,12 +149,12 @@ void NumpyStorage::send_event(ArrayMetadata &np_metas, PyArrayObject *numpy, PyO
     DBG("SEND_EVENT "<<i<<" elements");
     }
     DBG("SEND_EVENT "<<np_metas.get_array_size()<<"bytes");
-    myCache->get_writer()->send_event((char *) data, np_metas.get_array_size());
+    myCache->get_writer()->send_event(topic_name, (char *) data, np_metas.get_array_size());
 }
 
-void NumpyStorage::poll(ArrayMetadata &np_metas, PyArrayObject *numpy ) {
+void NumpyStorage::poll(const char* topic_name, ArrayMetadata &np_metas, PyArrayObject *numpy ) {
     void *data = PyArray_DATA(numpy);
-    this->getReadCache()->poll((char*)data, np_metas.get_array_size());
+    this->getReadCache()->poll(topic_name, (char*)data, np_metas.get_array_size());
 }
 
 /***

--- a/hecuba_core/src/py_interface/NumpyStorage.h
+++ b/hecuba_core/src/py_interface/NumpyStorage.h
@@ -39,8 +39,8 @@ public:
     void load_numpy_arrow(const uint64_t *storage_id, ArrayMetadata &np_metas, PyArrayObject *save, PyObject *cols);
     std::vector<uint64_t> get_cols(PyObject *coord) const;
 
-    void send_event(ArrayMetadata &np_metas, PyArrayObject *numpy, PyObject* coord);
-    void poll(ArrayMetadata &np_metas, PyArrayObject *numpy );
+    void send_event(const char* topic_name, ArrayMetadata &np_metas, PyArrayObject *numpy, PyObject* coord);
+    void poll(const char* topic_name, ArrayMetadata &np_metas, PyArrayObject *numpy );
 
 private:
 

--- a/hecuba_py/hecuba/hnumpy.py
+++ b/hecuba_py/hecuba/hnumpy.py
@@ -959,7 +959,7 @@ class StorageNumpy(IStorage, np.ndarray):
     def _initialize_stream_capability(self, topic_name=None):
         super()._initialize_stream_capability(topic_name)
         if topic_name is not None:
-            self._hcache.enable_stream(self._topic_name, {'kafka_names': str.join(",",config.kafka_names)})
+            self._hcache.enable_stream({'kafka_names': str.join(",",config.kafka_names)})
 
     def send(self, key=None, val=None):
         """
@@ -974,12 +974,12 @@ class StorageNumpy(IStorage, np.ndarray):
             self._initialize_stream_capability(self.storage_id)
 
         if not self._stream_producer_enabled:
-            self._hcache.enable_stream_producer()
+            self._hcache.enable_stream_producer(self._topic_name)
             self._stream_producer_enabled = True
 
         if key is None and val is None:
             # Send the WHOLE numpy
-            self._hcache.send_event(self._build_args.metas, [self._get_base_array()], None)
+            self._hcache.send_event(self._topic_name, self._build_args.metas, [self._get_base_array()], None)
 
         else:
             raise NotImplementedError("SEND partial numpy not supported")
@@ -994,7 +994,7 @@ class StorageNumpy(IStorage, np.ndarray):
             self._initialize_stream_capability(self.storage_id)
 
         if not self._stream_consumer_enabled:
-            self._hcache.enable_stream_consumer()
+            self._hcache.enable_stream_consumer(self._topic_name)
             self._stream_consumer_enabled=True
 
         self._hcache.poll(self._build_args.metas, [self._get_base_array()])


### PR DESCRIPTION
    * Object StorageIDs are used as topics for streaming. The problem is that
      typically a Writer creates a single producer and a single topic, as a
      Writer is associated to a table, which normally means a single object,
      but with the single table used to store numpys, streaming numpys was
      impossible, as a single writer is used for ALL numpys and only the first
      numpy is streamed correctly.

    * Add a single producer with multiple topics per Writer.

    * Regarding the consumers (CacheTable), there may be multiple storagenumpys
      per table, therefore, create one consumer per each topic.