### PR TITLE
Kafka and chonky numpys bug fixes

### DIFF
--- a/hecuba_core/CMakeLists.txt
+++ b/hecuba_core/CMakeLists.txt
@@ -200,8 +200,8 @@ if (NOT KAFKA)
     ExternalProject_Add(
         KAFKA   #KAFKA-prefix
         DOWNLOAD_DIR ${CMAKE_CURRENT_LIST_DIR}/dependencies
-        URL "https://github.com/edenhill/librdkafka/archive/refs/tags/v1.9.2.zip"
-        URL_HASH SHA256=4ecb0a3103022a7cab308e9fecd88237150901fa29980c99344218a84f497b86
+        URL "https://github.com/confluentinc/librdkafka/archive/refs/tags/v2.8.0.zip"
+        URL_HASH SHA256=5525efaad154e277e6ce30ab78bb00dbd882b5eeda6c69c9eeee69b7abee11a4
         INSTALL_DIR ${C_BINDING_INSTALL_PREFIX}
         CMAKE_COMMAND echo
         BUILD_COMMAND ./configure --prefix=${C_BINDING_INSTALL_PREFIX}
@@ -221,8 +221,8 @@ IF (NOT LIBUV)
     ExternalProject_Add(
             LIBUV
             DOWNLOAD_DIR ${CMAKE_CURRENT_LIST_DIR}/dependencies
-            URL "https://github.com/libuv/libuv/archive/v1.11.0.tar.gz"
-            URL_HASH SHA1=54f0972aa0d3f6a6036d477b381c01f030f9a2b5
+            URL "https://github.com/libuv/libuv/archive/refs/tags/v1.50.0.tar.gz"
+            URL_HASH SHA1=f79f488fbbf2846f3fd9ae2f75df993f9f33b838
             CMAKE_COMMAND echo
             BUILD_COMMAND sh autogen.sh COMMAND ./configure --prefix=${C_BINDING_INSTALL_PREFIX}
             BUILD_IN_SOURCE 1

--- a/hecuba_core/src/CacheTable.cpp
+++ b/hecuba_core/src/CacheTable.cpp
@@ -308,48 +308,15 @@ void  CacheTable::enable_stream_consumer(const char* topic_name) {
             fprintf(stderr, "%% Failed to create new consumer: %s\n", errstr);
             exit(1);
         }
-	std::cout << "[ENRIC KAFKA] CacheTable::enable_stream_consumer; rd_kafka_new" << std::endl;
 
-	rd_kafka_poll_set_consumer(rk); //enric
-	std::cout << "[ENRIC KAFKA] CacheTable::enable_stream_consumer; rd_kafka_poll_set_consumer" << std::endl;
-
+        rd_kafka_poll_set_consumer(rk);
 
         rd_kafka_resp_err_t err;
         rd_kafka_topic_partition_list_t* topics = rd_kafka_topic_partition_list_new(1);
-	std::cout << "[ENRIC KAFKA] CacheTable::enable_stream_consumer; rd_kafka_topic_partition_list_new" << std::endl;
-        //rd_kafka_topic_partition_list_add(topics, topic_name, RD_KAFKA_PARTITION_UA);
         rd_kafka_topic_partition_list_add(topics, topic_name, 0);
-	std::cout << "[ENRIC KAFKA] CacheTable::enable_stream_consumer; rd_kafka_topic_partition_list_add" << std::endl;
-
-/*
-        if ((err = rd_kafka_subscribe(rk, topics))) {
-            fprintf(stderr, "%% Failed to start consuming topics: %s\n", rd_kafka_err2str(err));
-            exit(1);
-        }
-	std::cout << "[ENRIC KAFKA] CacheTable::enable_stream_consumer; rd_kafka_subscribe" << std::endl;
-*/
 
         rd_kafka_assign(rk, topics);
-        /*
-        rd_kafka_topic_partition_list_t* current_topics;
-        bool finish = false;
-        while(!finish) {
-            err = rd_kafka_subscription(rk, &current_topics);
-	std::cout << "[ENRIC KAFKA] CacheTable::enable_stream_consumer; rd_kafka_subscription" << std::endl;
-            if (err) {
-                fprintf(stderr, "%% Failed to get topics: %s\n", rd_kafka_err2str(err));
-                exit(1);
-            }
-            if (current_topics->cnt == 0) {
-                fprintf(stderr, "%% Failed to get topics: NO ELEMENTS\n");
-            } else{
-                //fprintf(stderr, "%% I got you \n");
-                // fprintf(stderr, "%% I got you %s\n", current_topics->elems[0].topic);
-                finish = true;
-            }
 
-            rd_kafka_topic_partition_list_destroy(current_topics);
-        }
         kafkaConsumer[topic] = rk;
     }
 

--- a/hecuba_core/src/CacheTable.cpp
+++ b/hecuba_core/src/CacheTable.cpp
@@ -308,21 +308,34 @@ void  CacheTable::enable_stream_consumer(const char* topic_name) {
             fprintf(stderr, "%% Failed to create new consumer: %s\n", errstr);
             exit(1);
         }
+	std::cout << "[ENRIC KAFKA] CacheTable::enable_stream_consumer; rd_kafka_new" << std::endl;
+
+	rd_kafka_poll_set_consumer(rk); //enric
+	std::cout << "[ENRIC KAFKA] CacheTable::enable_stream_consumer; rd_kafka_poll_set_consumer" << std::endl;
 
 
         rd_kafka_resp_err_t err;
         rd_kafka_topic_partition_list_t* topics = rd_kafka_topic_partition_list_new(1);
-        rd_kafka_topic_partition_list_add(topics, topic_name, RD_KAFKA_PARTITION_UA);
+	std::cout << "[ENRIC KAFKA] CacheTable::enable_stream_consumer; rd_kafka_topic_partition_list_new" << std::endl;
+        //rd_kafka_topic_partition_list_add(topics, topic_name, RD_KAFKA_PARTITION_UA);
+        rd_kafka_topic_partition_list_add(topics, topic_name, 0);
+	std::cout << "[ENRIC KAFKA] CacheTable::enable_stream_consumer; rd_kafka_topic_partition_list_add" << std::endl;
 
+/*
         if ((err = rd_kafka_subscribe(rk, topics))) {
             fprintf(stderr, "%% Failed to start consuming topics: %s\n", rd_kafka_err2str(err));
             exit(1);
         }
+	std::cout << "[ENRIC KAFKA] CacheTable::enable_stream_consumer; rd_kafka_subscribe" << std::endl;
+*/
 
+        rd_kafka_assign(rk, topics);
+        /*
         rd_kafka_topic_partition_list_t* current_topics;
         bool finish = false;
         while(!finish) {
             err = rd_kafka_subscription(rk, &current_topics);
+	std::cout << "[ENRIC KAFKA] CacheTable::enable_stream_consumer; rd_kafka_subscription" << std::endl;
             if (err) {
                 fprintf(stderr, "%% Failed to get topics: %s\n", rd_kafka_err2str(err));
                 exit(1);

--- a/hecuba_core/src/CacheTable.cpp
+++ b/hecuba_core/src/CacheTable.cpp
@@ -313,6 +313,14 @@ void  CacheTable::enable_stream_consumer(const char* topic_name) {
 
         rd_kafka_resp_err_t err;
         rd_kafka_topic_partition_list_t* topics = rd_kafka_topic_partition_list_new(1);
+        /* Using a fixed partition avoids utilizing the configured
+         * partitioner function to select a target partition. 
+         * Always selecting a determined partition forces 
+         * every topic to have only one partition, which, in 
+         * this case, it is not a nuisance because for each 
+         * topic we only have one sender.
+         * By default we select the first available partition */
+        //esosa: si utilizamos otra partition o RD_KAFKA_PARTITION_UA no funciona  
         rd_kafka_topic_partition_list_add(topics, topic_name, 0);
 
         rd_kafka_assign(rk, topics);

--- a/hecuba_core/src/SpaceFillingCurve.cpp
+++ b/hecuba_core/src/SpaceFillingCurve.cpp
@@ -141,7 +141,7 @@ uint64_t ZorderCurveGenerator::computeZorder(std::vector<uint32_t> cc) {
     uint32_t nbits = (sizeof(uint64_t) * CHAR_BIT) / ndims;
     for (uint64_t i = 0; i < nbits; ++i) {
         for (uint64_t dim_i = 0; dim_i < ndims; ++dim_i) {
-            if (cc[dim_i] & ((uint64_t) 1 << i)) answer |= 1 << (ndims * i + dim_i);
+            if (cc[dim_i] & ((uint64_t) 1 << i)) answer |= (((uint64_t)1) << (ndims * i + dim_i));
         }
     }
     //std::cout<< "} => " << answer << std::endl;
@@ -487,7 +487,7 @@ void ZorderCurveGenerator::merge_partitions(const ArrayMetadata &metas, std::vec
     //For each partition compute the future position inside the new array
     //Achieved using the cluster_id and block_id to recompute the ZorderId
     for (Partition chunk : chunks) {
-        uint64_t zorder_id = chunk.cluster_id << CLUSTER_SIZE | chunk.block_id;
+	uint64_t zorder_id = (uint64_t)chunk.cluster_id << CLUSTER_SIZE | (uint64_t)chunk.block_id;
         //Compute position in memory
         std::vector<uint32_t> ccs = zorderInverse(zorder_id, ndims); //Block coordinates
         //if any element of the ccs is equal to dim_split -> is a limit of the array -> recompute chunk

--- a/hecuba_core/src/Writer.cpp
+++ b/hecuba_core/src/Writer.cpp
@@ -244,15 +244,13 @@ void Writer::send_event(const char* topic_name, char* event, const uint64_t size
                     RD_KAFKA_V_OPAQUE(NULL),
                     /* End sentinel */
                     RD_KAFKA_V_END);
-	std::cout << "[ENRIC KAFKA] Writer::send_event; rd_kafka_producev" << std::endl;
 	if (err) {
         char b[256];
         sprintf(b, "%% Failed to produce to topic %s: %s\n",
                 topic_name, rd_kafka_err2str(rd_kafka_errno2err(errno)));
         throw ModuleException(b);
 	}
-	rd_kafka_poll(producer, 0 /*non-blocking*/); //enric
-	std::cout << "[ENRIC KAFKA] Writer::send_event; rd_kafka_poll" << std::endl;
+	rd_kafka_poll(producer, 0 /*non-blocking*/);
     DBG("Writer::send_event. "<<size<<" bytes sent to "<<std::string(topic_name)<<"]");
 }
 

--- a/hecuba_core/src/Writer.cpp
+++ b/hecuba_core/src/Writer.cpp
@@ -244,12 +244,15 @@ void Writer::send_event(const char* topic_name, char* event, const uint64_t size
                     RD_KAFKA_V_OPAQUE(NULL),
                     /* End sentinel */
                     RD_KAFKA_V_END);
+	std::cout << "[ENRIC KAFKA] Writer::send_event; rd_kafka_producev" << std::endl;
 	if (err) {
         char b[256];
         sprintf(b, "%% Failed to produce to topic %s: %s\n",
                 topic_name, rd_kafka_err2str(rd_kafka_errno2err(errno)));
         throw ModuleException(b);
 	}
+	rd_kafka_poll(producer, 0 /*non-blocking*/); //enric
+	std::cout << "[ENRIC KAFKA] Writer::send_event; rd_kafka_poll" << std::endl;
     DBG("Writer::send_event. "<<size<<" bytes sent to "<<std::string(topic_name)<<"]");
 }
 

--- a/hecuba_core/src/Writer.cpp
+++ b/hecuba_core/src/Writer.cpp
@@ -250,7 +250,21 @@ void Writer::send_event(const char* topic_name, char* event, const uint64_t size
                 topic_name, rd_kafka_err2str(rd_kafka_errno2err(errno)));
         throw ModuleException(b);
 	}
+
+
+    /* A producer application should continually serve
+     * the delivery report queue by calling rd_kafka_poll()
+     * at frequent intervals.
+     * Either put the poll call in your main loop, or in a
+     * dedicated thread, or call it after every
+     * rd_kafka_produce() call.
+     * Just make sure that rd_kafka_poll() is still called
+     * during periods where you are not producing any messages
+     * to make sure previously produced messages have their
+     * delivery report callback served (and any other callbacks
+     * you register). */
 	rd_kafka_poll(producer, 0 /*non-blocking*/);
+
     DBG("Writer::send_event. "<<size<<" bytes sent to "<<std::string(topic_name)<<"]");
 }
 

--- a/hecuba_core/src/api/StorageNumpy.h
+++ b/hecuba_core/src/api/StorageNumpy.h
@@ -219,19 +219,21 @@ class StorageNumpy:virtual public IStorage {
 
             uint64_t total_size = numpy_metas.get_array_size();
             uint64_t offset = 0;
-            uint64_t partition_size = 262144;
-            while (offset < total_size) {
+            uint64_t partition_size = 262144; //arbitrarily use a large power of two number: 2^18
+            uint64_t pending = total_size-offset;
+            while (pending > 0) {
                 uint64_t actual_size;
                 //check if last partition is less than partition_size
-                if ((total_size-offset) < partition_size) {
-                    actual_size = total_size-offset;
+                if (pending < partition_size) {
+                    actual_size = pending;
                 } else {
                     actual_size = partition_size;
                 }
                 char* tmp = (char*)data;
-                getDataWriter()->send_event(UUID::UUID2str(getStorageID()).c_str(), &tmp[offset], actual_size);
+                getDataWriter()->send_event(UUID::UUID2str(getStorageID()).c_str(), &data[offset], actual_size);
 
                 offset += partition_size;
+                pending = total_size-offset;
             }
         }
 

--- a/hecuba_core/src/api/StorageNumpy.h
+++ b/hecuba_core/src/api/StorageNumpy.h
@@ -216,7 +216,23 @@ class StorageNumpy:virtual public IStorage {
 
         void send(void) {
             DBG("DEBUG: IStorage::send: sending numpy. Size "<< numpy_metas.get_array_size());
-            getDataWriter()->send_event(UUID::UUID2str(getStorageID()).c_str(), (char *) data, numpy_metas.get_array_size());
+
+            uint64_t total_size = numpy_metas.get_array_size();
+            uint64_t offset = 0;
+            uint64_t partition_size = 262144;
+            while (offset < total_size) {
+                uint64_t actual_size;
+                //check if last partition is less than partition_size
+                if ((total_size-offset) < partition_size) {
+                    actual_size = total_size-offset;
+                } else {
+                    actual_size = partition_size;
+                }
+                char* tmp = (char*)data;
+                getDataWriter()->send_event(UUID::UUID2str(getStorageID()).c_str(), &tmp[offset], actual_size);
+
+                offset += partition_size;
+            }
         }
 
         void writePythonSpec() {} // StorageNumpy do not have python specification

--- a/hecuba_core/src/api/StorageNumpy.h
+++ b/hecuba_core/src/api/StorageNumpy.h
@@ -160,7 +160,7 @@ class StorageNumpy:virtual public IStorage {
         }
 
         Writer * getDataWriter() const {
-            std::cout<< "getDataWriter numpy" << std::endl;
+            //std::cout<< "getDataWriter numpy" << std::endl;
             return this->arrayStore->getWriteCache()->get_writer();
         }
 


### PR DESCRIPTION
+ Fixed a bug that made Kafka unable to handle too big Numpys
+ Fixed a bug that made Hecuba not work with big Numpys when their dimensions were not multiple of 22
+ Fixed polling times that lasted 3 seconds regardless of Numpys size

