### PR TITLE
Enable polling data for StorageNumpy in the c++ api

### DIFF
--- a/examples/streaming/Makefile
+++ b/examples/streaming/Makefile
@@ -1,6 +1,9 @@
 CPPFLAGS=-g -std=c++11   -I ${HECUBA_ROOT}/include  -I ${HECUBA_ROOT}/include/hecuba  -L${HECUBA_ROOT}/lib   -lhfetch   -Wl,-rpath,${HECUBA_ROOT}/lib
 OBJS= \
     producer \
+	consumer_singlenumpy \
+	producer_singlenumpy \
+
 # DO NOT REMOVE THIS LINE (MARKS THE END OF THE 'OBJS' VARIABLE)
 
 all: ${HECUBA_ROOT}/lib/libhfetch.so ${OBJS}
@@ -15,6 +18,11 @@ producer: producer.cpp
 	@echo ==========================================================================
 	g++ -o producer  producer.cpp    ${CPPFLAGS}
 
+consumer_singlenumpy: consumer_singlenumpy.cpp
+	g++ -o consumer_singlenumpy  consumer_singlenumpy.cpp    ${CPPFLAGS}
+
+producer_singlenumpy: producer_singlenumpy.cpp
+	g++ -o producer_singlenumpy  producer_singlenumpy.cpp    ${CPPFLAGS}
 
 clean:
 	rm ${OBJS}

--- a/examples/streaming/consumer_singlenumpy.cpp
+++ b/examples/streaming/consumer_singlenumpy.cpp
@@ -1,0 +1,79 @@
+
+#include <StorageNumpy.h>
+#include <StorageStream.h>
+#include <iostream>
+
+class mynumpyclass: public StorageNumpy, public StorageStream {
+
+};
+
+void consumer_singleNumpy_int() {
+mynumpyclass mysn;
+
+mysn.getByAlias("myintnumpy");
+mysn.poll(); //wait on the stream for the numpy
+
+uint64_t *p = (uint64_t *) mysn.data;
+std::vector<unsigned int> metas = mysn.metas;
+
+for (int i=0; i<metas[0]; i++) {
+    for(int j=0; j<metas[1]; j++) {
+        std::cout << *p << std::endl;
+        p++;
+    }
+}
+
+mynumpyclass mysn2;
+mysn2.getByAlias("myintnumpy");
+mysn2.setNumpy(); //read the numpy from Cassandra
+
+p = (uint64_t*) mysn2.data;
+metas = mysn2.metas;
+
+for (int i=0; i<metas[0]; i++) {
+    for(int j=0; j<metas[1]; j++) {
+        std::cout << *p << std::endl;
+        p++;
+    }
+}
+
+
+}
+
+void consumer_singleNumpy_float() {
+mynumpyclass mysn;
+
+mysn.getByAlias("myfloatnumpy");
+mysn.poll(); //wait on the stream for the numpy
+
+double *p = (double *) mysn.data;
+std::vector<unsigned int> metas = mysn.metas;
+
+for (int i=0; i<metas[0]; i++) {
+    for(int j=0; j<metas[1]; j++) {
+        std::cout << *p << std::endl;
+        p++;
+    }
+}
+
+mynumpyclass mysn2;
+mysn2.getByAlias("myfloatnumpy");
+mysn2.setNumpy(); //read the numpy from Cassandra
+
+p = (double*) mysn2.data;
+metas = mysn2.metas;
+
+for (int i=0; i<metas[0]; i++) {
+    for(int j=0; j<metas[1]; j++) {
+        std::cout << *p << std::endl;
+        p++;
+    }
+}
+
+
+}
+
+main () {
+    consumer_singleNumpy_int();
+    consumer_singleNumpy_float();
+}

--- a/examples/streaming/consumer_singlenumpy.py
+++ b/examples/streaming/consumer_singlenumpy.py
@@ -1,0 +1,16 @@
+import numpy as np
+from mynumpyclass import mynumpyclass
+
+def consumer_singleNumpy_int():
+    mysn=mynumpyclass.get_by_alias("myintnumpy")
+    mysn.poll()
+    print(mysn)
+
+def consumer_singleNumpy_float():
+    mysn=mynumpyclass.get_by_alias("myfloatnumpy")
+    mysn.poll()
+    print(mysn)
+
+if __name__ == "__main__":
+    consumer_singleNumpy_int()
+    consumer_singleNumpy_float()

--- a/examples/streaming/mynumpyclass.py
+++ b/examples/streaming/mynumpyclass.py
@@ -1,0 +1,6 @@
+from hecuba import StorageStream, StorageNumpy
+
+class mynumpyclass(StorageNumpy,StorageStream):
+    '''
+    pass
+    '''

--- a/examples/streaming/producer_singlenumpy.cpp
+++ b/examples/streaming/producer_singlenumpy.cpp
@@ -1,0 +1,71 @@
+
+#include <StorageNumpy.h>
+#include <StorageStream.h>
+#include <iostream>
+
+#define ROWS 3
+#define COLS 4
+
+class mynumpyclass: public StorageNumpy, public StorageStream {
+
+};
+
+char * generateNumpyContent_int(const std::vector<uint32_t> &metas) {
+
+    uint64_t *numpy=(uint64_t *)malloc(sizeof(uint64_t )*metas[0]*metas[1]);
+    uint64_t  *tmp = numpy;
+    uint64_t  num = 1;
+    for (int i=0; i<metas[0]; i++) {
+        for (int j=0; j<metas[1]; j++) {
+            *tmp = num++;
+            std::cout<< "++ "<<i<<","<<j<<":" << *tmp<< std::endl;
+            tmp+=1;
+        }
+    }
+    std::cout<< "+ Generated NUMPY ["<<metas[0]<<", "<<metas[1]<<"] using "<<sizeof(int)*metas[0]*metas[1]<<"bytes at "<<std::hex<<(void*)numpy<<std::endl;
+    return (char*) numpy;
+}
+
+void producer_singleNumpy_int() {
+mynumpyclass mysn;
+std::vector<uint32_t> metadata = {ROWS, COLS};
+char* data = generateNumpyContent_int(metadata);
+
+    mysn.setNumpy(data,metadata,'i');
+	mysn.make_persistent("myintnumpy");
+    mysn.sync();
+    mysn.send();
+
+}
+char * generateNumpyContent_float(const std::vector<uint32_t> &metas) {
+
+    double *numpy=(double *)malloc(sizeof(double)*metas[0]*metas[1]);
+    double  *tmp = numpy;
+    double  num = 1.0;
+    for (int i=0; i<metas[0]; i++) {
+        for (int j=0; j<metas[1]; j++) {
+            *tmp = num++;
+            std::cout<< "++ "<<i<<","<<j<<":" << *tmp<< std::endl;
+            tmp+=1;
+        }
+    }
+    std::cout<< "+ Generated NUMPY ["<<metas[0]<<", "<<metas[1]<<"] using "<<sizeof(double)*metas[0]*metas[1]<<"bytes at "<<std::hex<<(void*)numpy<<std::endl;
+    return (char*) numpy;
+}
+
+void producer_singleNumpy_float() {
+mynumpyclass mysn;
+std::vector<uint32_t> metadata = {ROWS, COLS};
+char* data = generateNumpyContent_float(metadata);
+
+    mysn.setNumpy(data,metadata,'f');
+	mysn.make_persistent("myfloatnumpy");
+    mysn.sync();
+    mysn.send();
+
+}
+
+main () {
+    producer_singleNumpy_int();
+    producer_singleNumpy_float();
+}

--- a/examples/streaming/producer_singlenumpy.py
+++ b/examples/streaming/producer_singlenumpy.py
@@ -1,0 +1,16 @@
+import numpy as np
+from mynumpyclass import mynumpyclass
+
+def producer_singleNumpy_int():
+    n = np.arange(12,dtype=int).reshape(3,4) +1
+    mysn=mynumpyclass(n,"myintnumpy")
+    mysn.send()
+
+def producer_singleNumpy_float():
+    n = np.arange(12,dtype=float).reshape(3,4) +1
+    mysn=mynumpyclass(n,"myfloatnumpy")
+    mysn.send()
+
+if __name__ == "__main__":
+    producer_singleNumpy_int()
+    producer_singleNumpy_float()

--- a/hecuba_core/src/CacheTable.cpp
+++ b/hecuba_core/src/CacheTable.cpp
@@ -147,7 +147,8 @@ CacheTable::~CacheTable() {
        close_stream(x.first.c_str()); //send EOD to the consumer before deleting the writer
     }
 #endif
-    delete (writer);
+    if (writer != nullptr) 
+        delete (writer);
     if (myCache) {
         //stl tree calls deallocate for cache nodes on clear()->erase(), and later on destroy, which ends up calling the deleters
         myCache->clear();
@@ -300,7 +301,10 @@ void  CacheTable::enable_stream_consumer(const char* topic_name) {
     std::string topic = std::string(topic_name);
 
     if (kafkaConsumer.find(topic) != kafkaConsumer.end()) { // Topic already Exists
-        throw ModuleException(" Ooops. Stream "+topic+" already initialized.");
+        // yolandab: if the CacheTable is shared (numpy case) then it is possible to instantiate several times the same
+        // persistent object with the same topic and should not be a problem: change the throw by a return
+        //throw ModuleException(" Ooops. Stream "+topic+" already initialized.");
+        return;
     } else {
         /* Create Kafka consumer handle (1 consumer per topic) */
         rd_kafka_t *rk;

--- a/hecuba_core/src/Writer.cpp
+++ b/hecuba_core/src/Writer.cpp
@@ -207,7 +207,10 @@ void Writer::enable_stream(const char* topic_name, std::map<std::string, std::st
 
     std::string topic = std::string(topic_name);
     if (kafkaTopics.find(topic) != kafkaTopics.end()) { // Topic already Exists
-        throw ModuleException(" Ooops. Stream "+topic+" already initialized.");
+        // yolandab: if the CacheTable is shared (numpy case) then it is possible to instantiate several times the same
+        // persistent object with the same topic and should not be a problem: change the throw by a return
+        //throw ModuleException(" Ooops. Stream "+topic+" already initialized.");
+        return;
     } else {
         // Create topic
         rd_kafka_topic_t *rkt = rd_kafka_topic_new(producer, topic_name, NULL);

--- a/hecuba_core/src/api/IStorage.h
+++ b/hecuba_core/src/api/IStorage.h
@@ -55,6 +55,8 @@ class IStorage {
 
         virtual Writer * getDataWriter()const { return dataWriter;}
 
+        virtual void enableStreamConsumer(std::string topic) {DBG("VIRTUAL");}
+
         uint64_t* getStorageID();
         const std::string& getName() const;
 

--- a/hecuba_core/src/api/StorageNumpy.h
+++ b/hecuba_core/src/api/StorageNumpy.h
@@ -52,7 +52,10 @@ class StorageNumpy:virtual public IStorage {
                     );
             setObjSpec(snSpec);
             numpy_metas.typekind = dtype;
-            initializeClassName("StorageNumpy");
+            // 
+            // yolandab: delay the initialization of the class name outside the constructor 
+            // to get the actual name of the class. m
+            //initializeClassName("StorageNumpy");
         }
 
         StorageNumpy() {
@@ -81,6 +84,30 @@ class StorageNumpy:virtual public IStorage {
                 free(this->data);
             this->data = malloc(numpy_size);
             memcpy(this->data, datasrc, numpy_size);
+        }
+
+        // yolandab: setNumpy to be used after a getByAlias to support stream in of a numpy
+        // In the case of StorageDict the getByAlias method do not populate the dictionary, we delay the access to cassandra until the moment when the user access the elements
+        // In the case of StorageNuympy we have not define an interface to access the StorageNumpy so we decided to include in the getByAlias the retrieval of the whole StorageNumpy
+        // If we allow stream-in of StorageNumpy we need to allow the instantiation of a persistent storageNumpy without reading the data so I have moved the read from the getByAlias 
+        // (method setPersistence) to the new setNumpy without parameters. If the numpy is not a StorageStream then we use the setNumpy method in the setPersistence 
+        // (the behaviour is as before). If the numpy is a StorageStream that already exists and the user wants to stream out the data, then the user needs to call the 
+        // setNumpy method in the code.
+        // TODO: define an interface to access elements in a StorageNumpy
+        //
+
+        void setNumpy() {
+            // check that we have executed the setPersistence method
+            DBG("StorageNumpy:setNumpy: uuid: " << UUID::UUID2str(getStorageID()));
+            if (arrayStore == nullptr) {
+                throw ModuleException("StorageNumpy::setNumpy  setNumpy without parameters can only be used on a persistent object initialized from storage (get_by_alias method)"); 
+            } 
+            if (this->data != nullptr)
+                free(this->data);
+            this->data = malloc(numpy_metas.get_array_size());
+            std::list<std::vector<uint32_t>> coord = {};
+            DBG("StorageNumpy:setNumpy: launching read from cassandra ");
+            arrayStore->read_numpy_from_cas_by_coords(getStorageID(), numpy_metas, coord, data);
         }
 
         // StorageNumpy sn = misn;
@@ -117,7 +144,7 @@ class StorageNumpy:virtual public IStorage {
         ~StorageNumpy() {
 
             HecubaExtrae_event(HECUBAEV, HECUBA_SN|HECUBA_DESTROY);
-            //std::cout << " StorageNumpy::Destructor " << UUID::UUID2str(getStorageID())<<std::endl;
+            DBG( " StorageNumpy::Destructor " << UUID::UUID2str(getStorageID())<<std::endl);
             if (this->data != nullptr) {
                 free (this->data);
             }
@@ -152,6 +179,7 @@ class StorageNumpy:virtual public IStorage {
 
         void initialize_dataAcces() {
             // StorageNumpy
+            DBG("StorageNumpy:initialize_dataAccess");
             this->arrayStore = std::make_shared<ArrayDataStore> (getTableName().c_str(),
                     getCurrentSession().config["execution_name"].c_str(),
                     getCurrentSession().getStorageInterface(), getCurrentSession().config);
@@ -159,18 +187,31 @@ class StorageNumpy:virtual public IStorage {
             getCurrentSession().registerObject(arrayStore,getClassName());
         }
 
+        void enableStreamConsumer(std::string topic) {
+            DBG ("StorageNumpy::enableStream Consumer");
+            this->arrayStore->getReadCache()->enable_stream((std::map<std::string, std::string>&)getCurrentSession().config);
+            // yolandab: enable stream to poll this could be done with the first poll like in python
+            this->arrayStore->getReadCache()->enable_stream_consumer(topic.c_str());
+        }
+
+        //TODO delete this specialization of getDataWrite
         Writer * getDataWriter() const {
-            //std::cout<< "getDataWriter numpy" << std::endl;
+            DBG ("StorageNumpy::getDataWriter");
+            DBG ("StorageNumpy::getDataWriter arrayStore " << this->arrayStore);
+            DBG ("StorageNumpy::getDataWriter writeCache " << this->arrayStore->getWriteCache());
+            DBG ("StorageNumpy::getDataWriter writer     " << this->arrayStore->getWriteCache()->get_writer());
             return this->arrayStore->getWriteCache()->get_writer();
         }
 
         void persist_metadata(uint64_t* c_uuid) {
             // Register in hecuba.istorage
+            DBG ("StorageNumpy::persist_metadata");
             registerNumpy(this->numpy_metas,  getObjectName(), c_uuid);
         }
 
         void persist_data() {
             // Dump data into Cassandra
+            DBG ("StorageNumpy::persist_data");
             arrayStore->store_numpy_into_cas(getStorageID(), this->numpy_metas, this->data);
 
         }
@@ -178,6 +219,7 @@ class StorageNumpy:virtual public IStorage {
         /* setPersistence - Inicializes current instance to conform to uuid object. To be used on an empty instance. */
         void setPersistence (uint64_t *uuid) {
             // FQid_model: Fully Qualified name for the id_model: module_name.id_model
+            DBG("StorageNumpy: setPersistence: UUID"<<UUID::UUID2str(uuid)); 
             std::string FQid_model = this->getIdModel();
 
             struct metadata_info row = this->getMetaData(uuid);
@@ -209,9 +251,14 @@ class StorageNumpy:virtual public IStorage {
             // Create READ/WRITE cache accesses
             initialize_dataAcces();
 
-            this->data = malloc(numpy_metas.get_array_size());
-            std::list<std::vector<uint32_t>> coord = {};
-            arrayStore->read_numpy_from_cas_by_coords(uuid, numpy_metas, coord, data);
+            //yolandab: move these 3 lines to  read numpy  to setNumpy
+            //this->data = malloc(numpy_metas.get_array_size());
+            //std::list<std::vector<uint32_t>> coord = {};
+            //arrayStore->read_numpy_from_cas_by_coords(uuid, numpy_metas, coord, data);
+            //if the StorageNumpy is not defined to be a stream we load the data. If it is a numpy to stream out the user should call setNumpy in the code
+            if (!isStream()) {
+                setNumpy();
+            }
         }
 
         void send(void) {
@@ -237,6 +284,14 @@ class StorageNumpy:virtual public IStorage {
             }
         }
 
+        void poll(void) {
+            DBG("StorageNumpy: poll");
+            if (this->data)
+                free(this->data);
+            this->data = malloc(numpy_metas.get_array_size());
+            this->arrayStore->getReadCache()->poll(UUID::UUID2str(getStorageID()).c_str(), (char*)data, numpy_metas.get_array_size());
+        }
+
         void writePythonSpec() {} // StorageNumpy do not have python specification
 
     private:
@@ -247,10 +302,11 @@ class StorageNumpy:virtual public IStorage {
             switch(dtype) {
                 case 'f': //NPY_FLOAT
                           return sizeof(double);
-                case 'i': //NPY_BYTE
-                case 'u': //NPY_UBYTE
                 case 'b': //NPY_BOOL
                           return sizeof(char);
+                case 'i': //NPY_INT
+                case 'u': //NPY_UINT
+                          return sizeof(int64_t);
                 default: {
                              std::string msg ("StorageNumpy::getDtypeSize: Unsupported type [");
                              msg += dtype;
@@ -265,6 +321,8 @@ class StorageNumpy:virtual public IStorage {
             std::vector <uint32_t> strides;
 
             arr_metas.elem_size = getDtypeSize(dtype); // TODO: This should be a parameter!
+            DBG("StorageNumpy::extractNumpyMetadata. dtype "<< dtype);
+            DBG("StorageNumpy::extractNumpyMetadata. elem_size "<< arr_metas.elem_size);
             // decode void *metadatas
             uint64_t acum=1;
             uint64_t numpy_size=0;
@@ -291,6 +349,7 @@ class StorageNumpy:virtual public IStorage {
         void registerNumpy(ArrayMetadata &numpy_meta, std::string name, uint64_t* uuid) {
 
             //std::cout<< "DEBUG: HecubaSession::registerNumpy BEGIN "<< name << UUID::UUID2str(uuid)<<std::endl;
+            DBG("StorageNumpy::registerNumpy: name: " << name <<" UUID " << UUID::UUID2str(uuid));
             void *keys = std::malloc(sizeof(uint64_t *));
             uint64_t *c_uuid = (uint64_t *) malloc(sizeof(uint64_t) * 2);//new uint64_t[2];
             c_uuid[0] = *uuid;
@@ -318,6 +377,12 @@ class StorageNumpy:virtual public IStorage {
                 + sizeof(uint32_t)*numpy_meta.strides.size() // dims & strides
                 + sizeof(numpy_meta.typekind)
                 + sizeof(numpy_meta.byteorder);
+
+            DBG("StorageNumpy::registerNumpy. numpy_meta elem_size: "<< numpy_meta.elem_size);
+            DBG("StorageNumpy::registerNumpy. numpy_meta partition_type: "<<numpy_meta.partition_type);
+            DBG("StorageNumpy::registerNumpy. numpy_meta flags: "<< numpy_meta.flags);
+            DBG("StorageNumpy::registerNumpy. numpy_meta typekind: "<< numpy_meta.typekind);
+            DBG("StorageNumpy::registerNumpy. numpy_meta byteorder: "<< numpy_meta.byteorder);
 
             //allocate plus the bytes counter
             unsigned char *byte_array = (unsigned char *) malloc(size+ sizeof(uint64_t));
@@ -370,10 +435,16 @@ class StorageNumpy:virtual public IStorage {
             std::memcpy(values, &base_numpy, sizeof(uint64_t *));  // base_numpy
             offset_values += sizeof(unsigned char *);
 
-            char *class_name=(char*)malloc(strlen("hecuba.hnumpy.StorageNumpy")+1);
-            strcpy(class_name, "hecuba.hnumpy.StorageNumpy");
-            //std::cout<< "DEBUG: HecubaSession::registerNumpy &class_name = "<<class_name<<std::endl;
+            // yolandab: deal with classes that inherit from StorageNumpy. Needed to deal with StorageStream
+            //char *class_name=(char*)malloc(strlen("hecuba.hnumpy.StorageNumpy")+1);
+            //strcpy(class_name, "hecuba.hnumpy.StorageNumpy");
+            DBG("StorageNumpy::registerNumpy before getClassName");
+            const char*  class_nameSRC = getIdModel().c_str();
+            char *class_name=(char*)malloc(strlen(class_nameSRC)+1);
+            strcpy(class_name, class_nameSRC);
+            std::cout<< "DEBUG: HecubaSession::registerNumpy &class_name = "<<class_name<<std::endl;
             memcpy(values+offset_values, &class_name, sizeof(unsigned char *)); //class_name
+            DBG("StorageNumpy::registerNumpy after copying class_name");
             offset_values += sizeof(unsigned char *);
 
             //std::cout<< "DEBUG: HecubaSession::registerNumpy &name = "<<name_array<<std::endl;
@@ -389,6 +460,7 @@ class StorageNumpy:virtual public IStorage {
                 //getCurrentSession().getNumpyMetaWriter()->write_to_cassandra(keys, values);
                 //getCurrentSession().getNumpyMetaWriter()->wait_writes_completion(); // Ensure hecuba.istorage get all updates SYNCHRONOUSLY (to avoid race conditions with poll that may request a build_remotely on this new object)!
                 arrayStore->getMetaDataCache()->get_writer()->write_to_cassandra(keys, values);
+                // JJ TODO arrayStore->getMetaDataCache()->get_writer()->wait_writes_completion(); // Ensure hecuba.istorage get all updates SYNCHRONOUSLY (to avoid race conditions with poll that may request a build_remotely on this new object)!
                 arrayStore->getMetaDataCache()->get_writer()->wait_writes_completion(); // Ensure hecuba.istorage get all updates SYNCHRONOUSLY (to avoid race conditions with poll that may request a build_remotely on this new object)!
             }
             catch (std::exception &e) {
@@ -397,6 +469,7 @@ class StorageNumpy:virtual public IStorage {
                 throw e;
             };
 
+            DBG("StorageNumpy::registerNumpy. hecuba.istorage updated");
         }
 
         bool is_create_table_required(void) {

--- a/hecuba_core/src/debug.h
+++ b/hecuba_core/src/debug.h
@@ -17,7 +17,7 @@
 
 #define DBG(x...) \
         do {\
-            std::cout<< "DBG " << __func__ << ": " << x << std::endl;\
+            std::cerr<< "DBG [" << int(getpid()) << "] " << __func__ << ": " << x << std::endl;\
         } while(0)
 
 #define DBGHEXTOSTRING(_b, _size) \

--- a/hecuba_py/hecuba/IStorage.py
+++ b/hecuba_py/hecuba/IStorage.py
@@ -93,6 +93,8 @@ class IStorage(object):
         if not self.storage_id:
             self.storage_id = storage_id_from_name(name)
 
+        print("Istorage.py: name: {} storage_id: {}".format(name,self.storage_id), flush=True)
+
         # If found data, replace the constructor data
         if not getattr(self,'_tokens', None) :
             metas = get_istorage_attrs(self.storage_id)


### PR DESCRIPTION
* Added poll to StorageNumpy c++ api
* Changed behaviour of getByAlias for classes that inherit from StorageNuympy and StorageStream: does not load the data from Cassandra and the user needs to call setNumpy or poll to populate the data
* Added a method setNumpy without parameters intended to be used after a getByAlias to populate the StorageNumpy from Cassandra
* Added a virtual method enableStreamConsumer that at this moment is only implemented in StorageNumpy