### PR TITLE
Fix StorageNumpy with floats

### DIFF
--- a/examples/c++/simple_numpy_rw.cpp
+++ b/examples/c++/simple_numpy_rw.cpp
@@ -20,6 +20,20 @@ char * generateNumpyContent(const std::vector<uint32_t> &metas) {
     }
     return (char*) numpy;
 }
+char * generateNumpyContentFloat(const std::vector<uint32_t> &metas) {
+
+    float *numpy=(float*)malloc(sizeof(float)*metas[0]*metas[1]);
+    float *tmp = numpy;
+    float num = 1;
+    for (int i=0; i<metas[0]; i++) {
+        for (int j=0; j<metas[1]; j++) {
+            std::cout<< "++ "<<i<<","<<j<<std::endl;
+            *tmp = num++;
+            tmp+=1;
+        }
+    }
+    return (char*) numpy;
+}
 
 bool equalsNumpy(const StorageNumpy& s, double *data, std::vector<uint32_t> metas) {
 	// Check metas
@@ -46,12 +60,37 @@ bool equalsNumpy(const StorageNumpy& s, double *data, std::vector<uint32_t> meta
 	}
 	return true;
 }
+bool equalsNumpyFloat(const StorageNumpy& s, float *data, std::vector<uint32_t> metas) {
+	// Check metas
+	if (s.metas.size() != metas.size()) {
+		return false;
+	}
+	for (int i=0; i<metas.size(); i++) {
+		if (s.metas[i] != metas[i]) {
+			return false;
+		}
+	}
+	// Check Content
+	float* p = (float*)s.data;
+	float* q = data;
+	for (int i=0; i<metas[0]; i++) {
+		for (int j=0; j<metas[1]; j++) {
+			if (*p != *q) {
+				std::cout<< "++ "<<i<<","<<j<< "=" << *p << " == " << *q << std::endl;
+				return false;
+			}
+			p++;
+			q++;
+		}
+	}
+	return true;
+}
 
 
 void test_retrieve_simple(const char *name) {
     std::vector<uint32_t> metadata = {3, 4};
     char *data = generateNumpyContent(metadata);
-    StorageNumpy sn(data,metadata);
+    StorageNumpy sn(data,metadata); // 'c' by default == double == float64
 
     sn.make_persistent(name);
 
@@ -65,6 +104,23 @@ void test_retrieve_simple(const char *name) {
     }
 }
 
+void test_float(const char *name) {
+    std::vector<uint32_t> metadata = {3, 4};
+    char *data = generateNumpyContentFloat(metadata);
+    StorageNumpy sn(data,metadata, 'f'); //single floats
+
+    sn.make_persistent(name);
+
+    sn.sync();
+
+    StorageNumpy sn2;
+    sn2.getByAlias(name);
+
+    if (!equalsNumpyFloat(sn2, (float*)data, metadata)) {
+        std::cout << "Retrieved Numpy ["<< name<< "] contains unexpected content (differnt from stored). " <<std::endl;
+    }
+}
+
 
 
 int main() {
@@ -72,6 +128,10 @@ int main() {
 
     std::cout << "Starting test 1 " <<std::endl;
     test_retrieve_simple("mynumpytoread");
+
+    std::cout << "Starting test 2 " <<std::endl;
+    test_float("mynumpytoreadfloat");
+
 
     std::cout << "End tests " <<std::endl;
 }

--- a/hecuba_core/src/api/StorageNumpy.h
+++ b/hecuba_core/src/api/StorageNumpy.h
@@ -60,21 +60,21 @@ class StorageNumpy:virtual public IStorage {
 
         StorageNumpy() {
             HecubaExtrae_event(HECUBAEV, HECUBA_SN|HECUBA_INSTANTIATION);
-            initObjSpec('f'); // Float by default
+            initObjSpec('c'); // Float64 by default
             HecubaExtrae_event(HECUBAEV, HECUBA_END);
         }
 
         /* Note: 'dtype' uses the array-interface api which is slightly different from Python
          *  array-interface:https://numpy.org/doc/1.21/reference/arrays.interface.html#arrays-interface
          *  python: https://numpy.org/doc/stable/reference/arrays.dtypes.html */
-        StorageNumpy(void *datasrc, const std::vector<uint32_t> &metas,char dtype='f') { // TODO: change 'dtype' type to string or better add another parameter with the size
+        StorageNumpy(void *datasrc, const std::vector<uint32_t> &metas,char dtype='c') { // TODO: change 'dtype' type to string or better add another parameter with the size
             HecubaExtrae_event(HECUBAEV, HECUBA_SN|HECUBA_INSTANTIATION);
             setNumpy(datasrc, metas, dtype);
             initObjSpec(dtype);
             HecubaExtrae_event(HECUBAEV, HECUBA_END);
         }
 
-        void setNumpy(void *datasrc, const std::vector<uint32_t>&metas, char dtype='f') {
+        void setNumpy(void *datasrc, const std::vector<uint32_t>&metas, char dtype='c') {
             // Transform user metas to ArrayMetadata
             this->metas = metas; // make a copy of user 'metas'
             uint64_t numpy_size = extractNumpyMetaData(metas, dtype, this->numpy_metas );
@@ -300,8 +300,10 @@ class StorageNumpy:virtual public IStorage {
 
         uint32_t getDtypeSize(char dtype) const {
             switch(dtype) {
-                case 'f': //NPY_FLOAT
+                case 'c': //NPY_FLOAT
                           return sizeof(double);
+                case 'f': //NPY_FLOAT
+                          return sizeof(float);
                 case 'b': //NPY_BOOL
                           return sizeof(char);
                 case 'i': //NPY_INT


### PR DESCRIPTION
    * StorageNumpy by default used 'f' dtype which meant 'double', but this is incorrect as it does not match the definition from Numpy. In Numpy 'f' means 'floating point'... but it means single floating point, therefore 'float' in C.
    * This commit fixes this difference, and adds support for both 'float' (float32) and 'double' (float64), corresponding to types 'f' and 'c' respectively.